### PR TITLE
Add favorite heart buttons to flashback tips

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,12 @@
                 <h3>5-4-3-2-1グラウンディング</h3>
                 <p>見えるもの5つ、触れられるもの4つ、聞こえるもの3つ、香るもの2つ、味わえるもの1つを順に挙げて、感覚を現在に戻します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">02</span>
@@ -60,6 +66,12 @@
                 <h3>足裏で床を押し返す</h3>
                 <p>椅子に座り、足裏全体で床を強く押しながら「ここにいる」と唱えて、身体の重さを感じます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">03</span>
@@ -67,6 +79,12 @@
                 <h3>温度を切り替える</h3>
                 <p>冷たいタオルや保冷剤、または温かいマグカップに触れて、温度の変化で意識を引き戻します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">04</span>
@@ -74,6 +92,12 @@
                 <h3>特定の色探しゲーム</h3>
                 <p>「青いものを5つ見つける」などの課題を自分に出し、視覚を周囲の安全な情報に集中させます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">05</span>
@@ -81,6 +105,12 @@
                 <h3>香りのアンカーを使う</h3>
                 <p>安心できる香水やアロマを手首にさっと塗り、香りを嗅いで現在とのつながりを強めます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">06</span>
@@ -88,6 +118,12 @@
                 <h3>質感に集中する</h3>
                 <p>石、布、木など手触りの異なるものを触り、温度や硬さ、細部の感触を声に出して描写します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">07</span>
@@ -95,6 +131,12 @@
                 <h3>一口の水を丁寧に味わう</h3>
                 <p>常温の水を少し飲み、口内の感覚や喉を通る流れに意識を置いて落ち着きを取り戻します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">08</span>
@@ -102,6 +144,12 @@
                 <h3>音を3つ拾って言葉にする</h3>
                 <p>エアコンの音、遠くの車、鳥の声など、耳に届く音を具体的に言葉で説明して「今の音」に集中します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">09</span>
@@ -109,6 +157,12 @@
                 <h3>目に映るものをひたすら列挙する</h3>
                 <p>周囲の家具や壁の模様などを声に出して説明し、視覚情報を記述することで現実感を高めます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">10</span>
@@ -116,6 +170,12 @@
                 <h3>素足で床の感触を感じる</h3>
                 <p>安全が確保できる場所で靴下を脱ぎ、床の硬さや冷たさ、ざらつきを丁寧に味わいます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
           </ul>
         </article>
@@ -132,6 +192,12 @@
                 <h3>ボックスブリージング</h3>
                 <p>4秒吸って、4秒止めて、4秒吐き、4秒止める呼吸を数回繰り返し、リズムで落ち着きを作ります。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">12</span>
@@ -139,6 +205,12 @@
                 <h3>胸に手を当てて呼吸を感じる</h3>
                 <p>片手を胸、もう片方をお腹に置き、息を吸うたびに手が持ち上がる感覚を観察して現在に集中します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">13</span>
@@ -146,6 +218,12 @@
                 <h3>ハミングで長く吐く</h3>
                 <p>口を閉じて低い声でハミングし、ゆっくりと息を吐き切ることで迷走神経を刺激し安定を促します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">14</span>
@@ -153,6 +231,12 @@
                 <h3>筋肉の緊張と弛緩を交互に</h3>
                 <p>握り拳を5秒間ぎゅっと締め、ふっと力を抜く動きを全身の部位で繰り返して現在の身体感覚を取り戻します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">15</span>
@@ -160,6 +244,12 @@
                 <h3>腕を頭上に伸ばして深呼吸</h3>
                 <p>肩甲骨を広げるように腕をゆっくり持ち上げ、息を吐きながら下ろすことで胸郭を開きます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">16</span>
@@ -167,6 +257,12 @@
                 <h3>手足を30秒軽くシェイク</h3>
                 <p>両手両足を軽く振り、身体にたまった緊張を逃して「動ける」感覚を思い出します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">17</span>
@@ -174,6 +270,12 @@
                 <h3>片鼻呼吸でリズムを整える</h3>
                 <p>右手の親指で右鼻を塞ぎ左から吸い、薬指で左を塞いで右から吐く動作をゆっくり数回繰り返します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">18</span>
@@ -181,6 +283,12 @@
                 <h3>意識的に大きなあくびをする</h3>
                 <p>顔や顎を緩めるためにあくびの動作を繰り返し、身体全体の緊張をほどきます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">19</span>
@@ -188,6 +296,12 @@
                 <h3>セルフヘイヴニングタッチ</h3>
                 <p>腕や顔をゆっくり撫で下ろすタッチで皮膚を刺激し、安全な接触の感覚を取り戻します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">20</span>
@@ -195,6 +309,12 @@
                 <h3>掌を押し合わせて呼吸を合わせる</h3>
                 <p>胸の前で両手を合わせ、押し合う力と呼吸の長さをリンクさせて「今ここ」に集中します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
           </ul>
         </article>
@@ -211,6 +331,12 @@
                 <h3>今日の日時と場所を宣言する</h3>
                 <p>「今日は2023年◯月◯日、私は〇〇にいる」と声に出して、現在地を確認します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">22</span>
@@ -218,6 +344,12 @@
                 <h3>安心の合言葉を繰り返す</h3>
                 <p>「今は安全」「これは記憶」などの言葉を声に出し、現実と記憶を区別します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">23</span>
@@ -225,6 +357,12 @@
                 <h3>心の中でストップサインを描く</h3>
                 <p>頭の中に鮮やかな赤いストップサインを思い描き、「止まれ」とはっきり指示します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">24</span>
@@ -232,6 +370,12 @@
                 <h3>数字を逆に数える</h3>
                 <p>100から7ずつ引く、または50から3ずつ引くなど、集中力を使う計算で意識を切り替えます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">25</span>
@@ -239,6 +383,12 @@
                 <h3>周囲の文章を声に出して読む</h3>
                 <p>近くのポスターや本の一節を声に出して読み、言葉の意味に注意を向けます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">26</span>
@@ -246,6 +396,12 @@
                 <h3>次の予定を詳細に思い描く</h3>
                 <p>この後の食事や家事の手順を細かく想像し、未来志向のイメージで現在に戻ります。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">27</span>
@@ -253,6 +409,12 @@
                 <h3>安全な言葉を逆スペルで言う</h3>
                 <p>好きな言葉や名前を逆から言い、脳の処理を今のタスクに集中させます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">28</span>
@@ -260,6 +422,12 @@
                 <h3>カテゴリーゲームをする</h3>
                 <p>「果物」「動物」などテーマを決めて、思いつくものを順に挙げるゲームで注意をそらします。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">29</span>
@@ -267,6 +435,12 @@
                 <h3>目の前の物を5つの特徴で説明</h3>
                 <p>選んだ物について色・形・重さ・用途・質感を言葉にして、現実的な思考に切り替えます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">30</span>
@@ -274,6 +448,12 @@
                 <h3>「今は安全カード」を読み上げる</h3>
                 <p>ポケットに入れている安心メモやカードを取り出し、そこに書いた手順をゆっくり読みます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
           </ul>
         </article>
@@ -290,6 +470,12 @@
                 <h3>ブランケットにくるまる</h3>
                 <p>柔らかいブランケットで肩から包み込み、体温が戻るのを感じながら深呼吸します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">42</span>
@@ -297,6 +483,12 @@
                 <h3>温かい飲み物をゆっくり飲む</h3>
                 <p>ハーブティーや白湯を一口ごとに味わい、喉や胸が温まる過程に集中します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">43</span>
@@ -304,6 +496,12 @@
                 <h3>安心プレイリストを再生する</h3>
                 <p>3曲だけ聴くなど短い時間で終わるプレイリストを流し、音楽のリズムに身体を委ねます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">44</span>
@@ -311,6 +509,12 @@
                 <h3>安全な香りのハンドクリームを塗る</h3>
                 <p>お気に入りのハンドクリームを手に馴染ませ、香りと肌触りの両方を味わいます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">45</span>
@@ -318,6 +522,12 @@
                 <h3>短い日記を書く</h3>
                 <p>「今の気持ち」「今できること」を数行書き出し、感情を外に出して整理します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">46</span>
@@ -325,6 +535,12 @@
                 <h3>ペンで図形をなぞる</h3>
                 <p>紙に円や四角を繰り返し描き、手の動きと視線を同じリズムで整えます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">47</span>
@@ -332,6 +548,12 @@
                 <h3>穏やかな揺れをつくる</h3>
                 <p>椅子に座って体を左右にゆっくり揺らし、自己安定化の動きで安心感を育てます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">48</span>
@@ -339,6 +561,12 @@
                 <h3>セルフハグで温かさを感じる</h3>
                 <p>自分の肩を抱きしめ、背中を軽く撫でながら「ここにいて大丈夫」と自分に伝えます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">49</span>
@@ -346,6 +574,12 @@
                 <h3>安心キットを開く</h3>
                 <p>お気に入りの写真や香り、メモを入れたボックスを開け、安心を思い出すアイテムに触れます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">50</span>
@@ -353,6 +587,12 @@
                 <h3>5分タイマーで休息スペースをつくる</h3>
                 <p>タイマーをセットし、その間は毛布やクッションで作った安全な場所に身を置き休みます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
           </ul>
         </article>
@@ -369,6 +609,12 @@
                 <h3>信頼できる人に電話をかける</h3>
                 <p>「フラッシュバックが起きている」と伝え、声を聞きながら現在の出来事を共有します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">32</span>
@@ -376,6 +622,12 @@
                 <h3>準備しておいたメッセージを送る</h3>
                 <p>「いま辛いので返信がほしい」と書かれたテンプレートメッセージをすぐに送信して支援を求めます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">33</span>
@@ -383,6 +635,12 @@
                 <h3>安心できる声の録音を再生する</h3>
                 <p>自分や支援者が録音したガイド音声をイヤホンで聴き、声に合わせて呼吸を整えます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">34</span>
@@ -390,6 +648,12 @@
                 <h3>そばにいる人に今の状況を説明してもらう</h3>
                 <p>「ここは安全な場所だよ」と周囲の人に言ってもらい、現実確認を手伝ってもらいます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">35</span>
@@ -397,6 +661,12 @@
                 <h3>抱きしめクッションで安心感を得る</h3>
                 <p>大きめのクッションや抱き枕を胸に抱いて、包み込まれる感覚で神経を落ち着かせます。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">36</span>
@@ -404,6 +674,12 @@
                 <h3>ペットと触れ合う</h3>
                 <p>猫や犬などの毛並みを撫で、呼吸や鼓動を感じながら安心感を共有します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">37</span>
@@ -411,6 +687,12 @@
                 <h3>安心できる写真を見る</h3>
                 <p>大切な人や心地よい景色の写真を眺め、「この時間に守られている」感覚を思い出します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">38</span>
@@ -418,6 +700,12 @@
                 <h3>短いサポートラインに連絡する</h3>
                 <p>地域や専門機関の24時間ホットライン・チャットにアクセスし、ガイドに沿って落ち着く手順を確認します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">39</span>
@@ -425,6 +713,12 @@
                 <h3>合図で助けを求める</h3>
                 <p>信頼できる人と決めた合図（手のジェスチャーやスタンプ）を送り、サポートを受け取ります。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
             <li>
               <span class="tip-number">40</span>
@@ -432,6 +726,12 @@
                 <h3>励ましの手紙を読み返す</h3>
                 <p>以前もらった応援のメッセージや自分宛の手紙を読み、支えられてきた事実を思い出します。</p>
               </div>
+              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
+                <span class="sr-only">お気に入りに追加</span>
+                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
+                </svg>
+              </button>
             </li>
           </ul>
         </article>
@@ -480,5 +780,42 @@
     </div>
     
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var favoriteButtons = document.querySelectorAll('.favorite-button');
+
+      favoriteButtons.forEach(function (button) {
+        var listItem = button.closest('li');
+        var heading = listItem ? listItem.querySelector('h3') : null;
+
+        if (heading) {
+          var title = heading.textContent.trim();
+          var labelAdd = '「' + title + '」をお気に入りに追加';
+          var labelRemove = '「' + title + '」のお気に入りを解除';
+          button.dataset.labelAdd = labelAdd;
+          button.dataset.labelRemove = labelRemove;
+          button.setAttribute('aria-label', labelAdd);
+        }
+
+        button.addEventListener('click', function () {
+          var isPressed = button.getAttribute('aria-pressed') === 'true';
+          var nextState = !isPressed;
+          button.setAttribute('aria-pressed', String(nextState));
+
+          if (button.dataset.labelAdd && button.dataset.labelRemove) {
+            button.setAttribute(
+              'aria-label',
+              nextState ? button.dataset.labelRemove : button.dataset.labelAdd
+            );
+          }
+
+          var srText = button.querySelector('.sr-only');
+          if (srText) {
+            srText.textContent = nextState ? 'お気に入りを解除' : 'お気に入りに追加';
+          }
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,19 @@ img {
   display: block;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .inner {
   width: min(1100px, 90vw);
   margin: 0 auto;
@@ -221,12 +234,16 @@ section {
   border-radius: 22px;
   padding: 1.5rem 1.4rem 1.45rem 1.4rem;
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
   gap: 1.1rem;
   align-items: start;
   border: 1px solid rgba(237, 122, 122, 0.12);
   box-shadow: 0 8px 24px rgba(121, 137, 162, 0.12);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tip-list li > div {
+  min-width: 0;
 }
 
 .tip-list li:hover,
@@ -261,6 +278,68 @@ section {
   margin: 0.45rem 0 0;
   color: var(--text-muted);
   font-size: 0.97rem;
+}
+
+.favorite-button {
+  align-self: start;
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(237, 122, 122, 0.25);
+  background: rgba(237, 122, 122, 0.12);
+  color: var(--accent);
+  font: inherit;
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.favorite-button:hover {
+  background: rgba(237, 122, 122, 0.2);
+  border-color: rgba(237, 122, 122, 0.45);
+}
+
+.favorite-button:focus-visible {
+  outline: 3px solid rgba(237, 122, 122, 0.28);
+  outline-offset: 2px;
+}
+
+.favorite-button:active {
+  transform: scale(0.95);
+}
+
+.favorite-button[aria-pressed="true"] {
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 8px 18px rgba(237, 122, 122, 0.25);
+}
+
+.favorite-button[aria-pressed="true"]:hover,
+.favorite-button[aria-pressed="true"]:focus-visible {
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  border-color: transparent;
+}
+
+.favorite-button .heart-icon {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  transition: transform 0.25s ease, fill 0.25s ease, stroke 0.25s ease;
+}
+
+.favorite-button[aria-pressed="true"] .heart-icon {
+  fill: currentColor;
+  stroke: currentColor;
+  transform: scale(1.05);
 }
 
 .note {
@@ -339,6 +418,11 @@ section {
     width: 44px;
     height: 44px;
     border-radius: 12px;
+  }
+
+  .favorite-button {
+    width: 40px;
+    height: 40px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a heart-shaped favorite button to every tip entry with accessible helper text
- style the new control and layout so the heart sits beside each tip on desktop and mobile
- add a small script to toggle the pressed state and update the aria label when the heart is clicked

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf7b57f8148326a6345ede222eea3e