### PR TITLE
Make intro and usage text more concise

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="フラッシュバックが起きた瞬間に使える、50個の応急対処法をまとめたガイド。五感・呼吸・意識の切り替え・サポートとのつながりなど、すぐに実践できるアイデアを丁寧に紹介します。">
+  <meta name="description" content="フラッシュバックの瞬間に使える応急対処法50選。五感・呼吸・意識の切り替えなど、今すぐ試せるアイデアを紹介します。">
   <title>フラッシュバック応急対処ガイド</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -26,7 +26,7 @@
         <span class="eyebrow-label">Flashback First Aid</span>
       </p>
       <h1>フラッシュバック<br>応急対処リスト</h1>
-      <p class="lead">記憶の波に飲み込まれそうになった瞬間に、「今ここ」に戻るための50のアイデア。<br>専門的な治療を補う、日常のセルフケアとしてご活用ください。</p>
+      <p class="lead">記憶の波に飲まれそうな瞬間に「今ここ」へ戻るための50の応急アイデア集。日常のセルフケアとしてご活用ください。</p>
     </div>
   </header>
 
@@ -34,8 +34,7 @@
     <section class="intro">
       <div class="inner">
         <h2>使い方</h2>
-        <p>以下のリストは、フラッシュバックが起きた直後に「とりあえず今すぐできること」をまとめた応急処置のアイデアです。<br>
-          根本的な治療や記憶の整理を置き換えるものではなく、安全が確保されていることを確認した上で、無理のない範囲で試してみてください。</p>
+        <p>フラッシュバック直後に試せる応急策を集めました。安全を確かめた上で、無理のない範囲で取り入れてください。</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- shorten the page meta description copy
- condense the hero lead sentence for the introduction
- streamline the usage instructions paragraph in the intro section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf8667cb008326bec3b6bddc750ac8