### PR TITLE
Refactor tip list rendering and scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <section class="intro">
       <div class="inner">
         <h2>使い方</h2>
-         <p>以下のリストは、フラッシュバックが起きた直後に「とりあえず今すぐできること」をまとめた応急処置のアイデアです。<br>
+        <p>以下のリストは、フラッシュバックが起きた直後に「とりあえず今すぐできること」をまとめた応急処置のアイデアです。<br>
           根本的な治療や記憶の整理を置き換えるものではなく、安全が確保されていることを確認した上で、無理のない範囲で試してみてください。</p>
       </div>
     </section>
@@ -46,138 +46,68 @@
             <h2>五感で「今」をつかまえる</h2>
             <p>感覚を目の前の現実に向け直し、過去の映像から距離を取るための手がかりです。</p>
           </header>
-          <ul class="tip-list">
-            <li>
-              <span class="tip-number">01</span>
-              <div>
+          <ol class="tip-list" start="1">
+            <li data-tip-id="tip-01">
+              <div class="tip-content">
                 <h3>5-4-3-2-1グラウンディング</h3>
                 <p>見えるもの5つ、触れられるもの4つ、聞こえるもの3つ、香るもの2つ、味わえるもの1つを順に挙げて、感覚を現在に戻します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">02</span>
-              <div>
+            <li data-tip-id="tip-02">
+              <div class="tip-content">
                 <h3>足裏で床を押し返す</h3>
                 <p>椅子に座り、足裏全体で床を強く押しながら「ここにいる」と唱えて、身体の重さを感じます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">03</span>
-              <div>
+            <li data-tip-id="tip-03">
+              <div class="tip-content">
                 <h3>温度を切り替える</h3>
                 <p>冷たいタオルや保冷剤、または温かいマグカップに触れて、温度の変化で意識を引き戻します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">04</span>
-              <div>
+            <li data-tip-id="tip-04">
+              <div class="tip-content">
                 <h3>特定の色探しゲーム</h3>
                 <p>「青いものを5つ見つける」などの課題を自分に出し、視覚を周囲の安全な情報に集中させます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">05</span>
-              <div>
+            <li data-tip-id="tip-05">
+              <div class="tip-content">
                 <h3>香りのアンカーを使う</h3>
                 <p>安心できる香水やアロマを手首にさっと塗り、香りを嗅いで現在とのつながりを強めます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">06</span>
-              <div>
+            <li data-tip-id="tip-06">
+              <div class="tip-content">
                 <h3>質感に集中する</h3>
                 <p>石、布、木など手触りの異なるものを触り、温度や硬さ、細部の感触を声に出して描写します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">07</span>
-              <div>
+            <li data-tip-id="tip-07">
+              <div class="tip-content">
                 <h3>一口の水を丁寧に味わう</h3>
                 <p>常温の水を少し飲み、口内の感覚や喉を通る流れに意識を置いて落ち着きを取り戻します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">08</span>
-              <div>
+            <li data-tip-id="tip-08">
+              <div class="tip-content">
                 <h3>音を3つ拾って言葉にする</h3>
                 <p>エアコンの音、遠くの車、鳥の声など、耳に届く音を具体的に言葉で説明して「今の音」に集中します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">09</span>
-              <div>
+            <li data-tip-id="tip-09">
+              <div class="tip-content">
                 <h3>目に映るものをひたすら列挙する</h3>
                 <p>周囲の家具や壁の模様などを声に出して説明し、視覚情報を記述することで現実感を高めます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">10</span>
-              <div>
+            <li data-tip-id="tip-10">
+              <div class="tip-content">
                 <h3>素足で床の感触を感じる</h3>
                 <p>安全が確保できる場所で靴下を脱ぎ、床の硬さや冷たさ、ざらつきを丁寧に味わいます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-          </ul>
+          </ol>
         </article>
 
         <article class="category">
@@ -185,138 +115,68 @@
             <h2>呼吸と身体を整える</h2>
             <p>呼吸と筋肉の働きを整えることで、自律神経を落ち着かせ、過去の映像から距離を取ります。</p>
           </header>
-          <ul class="tip-list">
-            <li>
-              <span class="tip-number">11</span>
-              <div>
+          <ol class="tip-list" start="11">
+            <li data-tip-id="tip-11">
+              <div class="tip-content">
                 <h3>ボックスブリージング</h3>
                 <p>4秒吸って、4秒止めて、4秒吐き、4秒止める呼吸を数回繰り返し、リズムで落ち着きを作ります。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">12</span>
-              <div>
+            <li data-tip-id="tip-12">
+              <div class="tip-content">
                 <h3>胸に手を当てて呼吸を感じる</h3>
                 <p>片手を胸、もう片方をお腹に置き、息を吸うたびに手が持ち上がる感覚を観察して現在に集中します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">13</span>
-              <div>
+            <li data-tip-id="tip-13">
+              <div class="tip-content">
                 <h3>ハミングで長く吐く</h3>
                 <p>口を閉じて低い声でハミングし、ゆっくりと息を吐き切ることで迷走神経を刺激し安定を促します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">14</span>
-              <div>
+            <li data-tip-id="tip-14">
+              <div class="tip-content">
                 <h3>筋肉の緊張と弛緩を交互に</h3>
                 <p>握り拳を5秒間ぎゅっと締め、ふっと力を抜く動きを全身の部位で繰り返して現在の身体感覚を取り戻します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">15</span>
-              <div>
+            <li data-tip-id="tip-15">
+              <div class="tip-content">
                 <h3>腕を頭上に伸ばして深呼吸</h3>
                 <p>肩甲骨を広げるように腕をゆっくり持ち上げ、息を吐きながら下ろすことで胸郭を開きます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">16</span>
-              <div>
+            <li data-tip-id="tip-16">
+              <div class="tip-content">
                 <h3>手足を30秒軽くシェイク</h3>
                 <p>両手両足を軽く振り、身体にたまった緊張を逃して「動ける」感覚を思い出します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">17</span>
-              <div>
+            <li data-tip-id="tip-17">
+              <div class="tip-content">
                 <h3>片鼻呼吸でリズムを整える</h3>
                 <p>右手の親指で右鼻を塞ぎ左から吸い、薬指で左を塞いで右から吐く動作をゆっくり数回繰り返します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">18</span>
-              <div>
+            <li data-tip-id="tip-18">
+              <div class="tip-content">
                 <h3>意識的に大きなあくびをする</h3>
                 <p>顔や顎を緩めるためにあくびの動作を繰り返し、身体全体の緊張をほどきます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">19</span>
-              <div>
+            <li data-tip-id="tip-19">
+              <div class="tip-content">
                 <h3>セルフヘイヴニングタッチ</h3>
                 <p>腕や顔をゆっくり撫で下ろすタッチで皮膚を刺激し、安全な接触の感覚を取り戻します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">20</span>
-              <div>
+            <li data-tip-id="tip-20">
+              <div class="tip-content">
                 <h3>掌を押し合わせて呼吸を合わせる</h3>
                 <p>胸の前で両手を合わせ、押し合う力と呼吸の長さをリンクさせて「今ここ」に集中します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-          </ul>
+          </ol>
         </article>
 
         <article class="category">
@@ -324,277 +184,68 @@
             <h2>意識の方向を切り替える</h2>
             <p>頭の中の映像から注意を外し、言葉や思考を現在の安全に向け直します。</p>
           </header>
-          <ul class="tip-list">
-            <li>
-              <span class="tip-number">21</span>
-              <div>
+          <ol class="tip-list" start="21">
+            <li data-tip-id="tip-21">
+              <div class="tip-content">
                 <h3>今日の日時と場所を宣言する</h3>
                 <p>「今日は2023年◯月◯日、私は〇〇にいる」と声に出して、現在地を確認します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">22</span>
-              <div>
+            <li data-tip-id="tip-22">
+              <div class="tip-content">
                 <h3>安心の合言葉を繰り返す</h3>
                 <p>「今は安全」「これは記憶」などの言葉を声に出し、現実と記憶を区別します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">23</span>
-              <div>
+            <li data-tip-id="tip-23">
+              <div class="tip-content">
                 <h3>心の中でストップサインを描く</h3>
                 <p>頭の中に鮮やかな赤いストップサインを思い描き、「止まれ」とはっきり指示します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">24</span>
-              <div>
+            <li data-tip-id="tip-24">
+              <div class="tip-content">
                 <h3>数字を逆に数える</h3>
                 <p>100から7ずつ引く、または50から3ずつ引くなど、集中力を使う計算で意識を切り替えます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">25</span>
-              <div>
+            <li data-tip-id="tip-25">
+              <div class="tip-content">
                 <h3>周囲の文章を声に出して読む</h3>
                 <p>近くのポスターや本の一節を声に出して読み、言葉の意味に注意を向けます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">26</span>
-              <div>
+            <li data-tip-id="tip-26">
+              <div class="tip-content">
                 <h3>次の予定を詳細に思い描く</h3>
                 <p>この後の食事や家事の手順を細かく想像し、未来志向のイメージで現在に戻ります。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">27</span>
-              <div>
+            <li data-tip-id="tip-27">
+              <div class="tip-content">
                 <h3>安全な言葉を逆スペルで言う</h3>
                 <p>好きな言葉や名前を逆から言い、脳の処理を今のタスクに集中させます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">28</span>
-              <div>
+            <li data-tip-id="tip-28">
+              <div class="tip-content">
                 <h3>カテゴリーゲームをする</h3>
                 <p>「果物」「動物」などテーマを決めて、思いつくものを順に挙げるゲームで注意をそらします。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">29</span>
-              <div>
+            <li data-tip-id="tip-29">
+              <div class="tip-content">
                 <h3>目の前の物を5つの特徴で説明</h3>
                 <p>選んだ物について色・形・重さ・用途・質感を言葉にして、現実的な思考に切り替えます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">30</span>
-              <div>
+            <li data-tip-id="tip-30">
+              <div class="tip-content">
                 <h3>「今は安全カード」を読み上げる</h3>
                 <p>ポケットに入れている安心メモやカードを取り出し、そこに書いた手順をゆっくり読みます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-          </ul>
-        </article>
-
-        <article class="category">
-          <header>
-            <h2>安心感を育てるセルフケア</h2>
-            <p>身体と心にやさしい刺激を与えて、今すぐできる「安心の種」をまきます。</p>
-          </header>
-          <ul class="tip-list">
-            <li>
-              <span class="tip-number">41</span>
-              <div>
-                <h3>ブランケットにくるまる</h3>
-                <p>柔らかいブランケットで肩から包み込み、体温が戻るのを感じながら深呼吸します。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">42</span>
-              <div>
-                <h3>温かい飲み物をゆっくり飲む</h3>
-                <p>ハーブティーや白湯を一口ごとに味わい、喉や胸が温まる過程に集中します。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">43</span>
-              <div>
-                <h3>安心プレイリストを再生する</h3>
-                <p>3曲だけ聴くなど短い時間で終わるプレイリストを流し、音楽のリズムに身体を委ねます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">44</span>
-              <div>
-                <h3>安全な香りのハンドクリームを塗る</h3>
-                <p>お気に入りのハンドクリームを手に馴染ませ、香りと肌触りの両方を味わいます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">45</span>
-              <div>
-                <h3>短い日記を書く</h3>
-                <p>「今の気持ち」「今できること」を数行書き出し、感情を外に出して整理します。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">46</span>
-              <div>
-                <h3>ペンで図形をなぞる</h3>
-                <p>紙に円や四角を繰り返し描き、手の動きと視線を同じリズムで整えます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">47</span>
-              <div>
-                <h3>穏やかな揺れをつくる</h3>
-                <p>椅子に座って体を左右にゆっくり揺らし、自己安定化の動きで安心感を育てます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">48</span>
-              <div>
-                <h3>セルフハグで温かさを感じる</h3>
-                <p>自分の肩を抱きしめ、背中を軽く撫でながら「ここにいて大丈夫」と自分に伝えます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">49</span>
-              <div>
-                <h3>安心キットを開く</h3>
-                <p>お気に入りの写真や香り、メモを入れたボックスを開け、安心を思い出すアイテムに触れます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-            <li>
-              <span class="tip-number">50</span>
-              <div>
-                <h3>5分タイマーで休息スペースをつくる</h3>
-                <p>タイマーをセットし、その間は毛布やクッションで作った安全な場所に身を置き休みます。</p>
-              </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
-            </li>
-          </ul>
+          </ol>
         </article>
 
         <article class="category">
@@ -602,138 +253,137 @@
             <h2>つながりとサポートを頼る</h2>
             <p>信頼できる人や環境との接点を思い出すことで、一人ではない感覚を取り戻します。</p>
           </header>
-          <ul class="tip-list">
-            <li>
-              <span class="tip-number">31</span>
-              <div>
+          <ol class="tip-list" start="31">
+            <li data-tip-id="tip-31">
+              <div class="tip-content">
                 <h3>信頼できる人に電話をかける</h3>
                 <p>「フラッシュバックが起きている」と伝え、声を聞きながら現在の出来事を共有します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">32</span>
-              <div>
+            <li data-tip-id="tip-32">
+              <div class="tip-content">
                 <h3>準備しておいたメッセージを送る</h3>
                 <p>「いま辛いので返信がほしい」と書かれたテンプレートメッセージをすぐに送信して支援を求めます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">33</span>
-              <div>
+            <li data-tip-id="tip-33">
+              <div class="tip-content">
                 <h3>安心できる声の録音を再生する</h3>
                 <p>自分や支援者が録音したガイド音声をイヤホンで聴き、声に合わせて呼吸を整えます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">34</span>
-              <div>
+            <li data-tip-id="tip-34">
+              <div class="tip-content">
                 <h3>そばにいる人に今の状況を説明してもらう</h3>
                 <p>「ここは安全な場所だよ」と周囲の人に言ってもらい、現実確認を手伝ってもらいます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">35</span>
-              <div>
+            <li data-tip-id="tip-35">
+              <div class="tip-content">
                 <h3>抱きしめクッションで安心感を得る</h3>
                 <p>大きめのクッションや抱き枕を胸に抱いて、包み込まれる感覚で神経を落ち着かせます。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">36</span>
-              <div>
+            <li data-tip-id="tip-36">
+              <div class="tip-content">
                 <h3>ペットと触れ合う</h3>
                 <p>猫や犬などの毛並みを撫で、呼吸や鼓動を感じながら安心感を共有します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">37</span>
-              <div>
+            <li data-tip-id="tip-37">
+              <div class="tip-content">
                 <h3>安心できる写真を見る</h3>
                 <p>大切な人や心地よい景色の写真を眺め、「この時間に守られている」感覚を思い出します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">38</span>
-              <div>
+            <li data-tip-id="tip-38">
+              <div class="tip-content">
                 <h3>短いサポートラインに連絡する</h3>
                 <p>地域や専門機関の24時間ホットライン・チャットにアクセスし、ガイドに沿って落ち着く手順を確認します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">39</span>
-              <div>
+            <li data-tip-id="tip-39">
+              <div class="tip-content">
                 <h3>合図で助けを求める</h3>
                 <p>信頼できる人と決めた合図（手のジェスチャーやスタンプ）を送り、サポートを受け取ります。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-            <li>
-              <span class="tip-number">40</span>
-              <div>
+            <li data-tip-id="tip-40">
+              <div class="tip-content">
                 <h3>励ましの手紙を読み返す</h3>
                 <p>以前もらった応援のメッセージや自分宛の手紙を読み、支えられてきた事実を思い出します。</p>
               </div>
-              <button class="favorite-button" type="button" aria-pressed="false" aria-label="お気に入りに追加">
-                <span class="sr-only">お気に入りに追加</span>
-                <svg class="heart-icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path>
-                </svg>
-              </button>
             </li>
-          </ul>
+          </ol>
+        </article>
+
+        <article class="category">
+          <header>
+            <h2>安心感を育てるセルフケア</h2>
+            <p>身体と心にやさしい刺激を与えて、今すぐできる「安心の種」をまきます。</p>
+          </header>
+          <ol class="tip-list" start="41">
+            <li data-tip-id="tip-41">
+              <div class="tip-content">
+                <h3>ブランケットにくるまる</h3>
+                <p>柔らかいブランケットで肩から包み込み、体温が戻るのを感じながら深呼吸します。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-42">
+              <div class="tip-content">
+                <h3>温かい飲み物をゆっくり飲む</h3>
+                <p>ハーブティーや白湯を一口ごとに味わい、喉や胸が温まる過程に集中します。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-43">
+              <div class="tip-content">
+                <h3>安心プレイリストを再生する</h3>
+                <p>3曲だけ聴くなど短い時間で終わるプレイリストを流し、音楽のリズムに身体を委ねます。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-44">
+              <div class="tip-content">
+                <h3>安全な香りのハンドクリームを塗る</h3>
+                <p>お気に入りのハンドクリームを手に馴染ませ、香りと肌触りの両方を味わいます。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-45">
+              <div class="tip-content">
+                <h3>短い日記を書く</h3>
+                <p>「今の気持ち」「今できること」を数行書き出し、感情を外に出して整理します。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-46">
+              <div class="tip-content">
+                <h3>ペンで図形をなぞる</h3>
+                <p>紙に円や四角を繰り返し描き、手の動きと視線を同じリズムで整えます。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-47">
+              <div class="tip-content">
+                <h3>穏やかな揺れをつくる</h3>
+                <p>椅子に座って体を左右にゆっくり揺らし、自己安定化の動きで安心感を育てます。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-48">
+              <div class="tip-content">
+                <h3>セルフハグで温かさを感じる</h3>
+                <p>自分の肩を抱きしめ、背中を軽く撫でながら「ここにいて大丈夫」と自分に伝えます。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-49">
+              <div class="tip-content">
+                <h3>安心キットを開く</h3>
+                <p>お気に入りの写真や香り、メモを入れたボックスを開け、安心を思い出すアイテムに触れます。</p>
+              </div>
+            </li>
+            <li data-tip-id="tip-50">
+              <div class="tip-content">
+                <h3>5分タイマーで休息スペースをつくる</h3>
+                <p>タイマーをセットし、その間は毛布やクッションで作った安全な場所に身を置き休みます。</p>
+              </div>
+            </li>
+          </ol>
         </article>
       </div>
     </section>
@@ -750,7 +400,7 @@
   <footer class="site-footer">
     <div class="inner">
       <p>あなたが安全でいられることが最優先です。必要に応じて、信頼できる専門家のサポートを受けてください。</p>
-      
+
       <div class="social-links">
         <a href="https://x.com/riccahigh" target="_blank" rel="noopener noreferrer" aria-label="X（旧Twitter）でフォロー">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
@@ -775,170 +425,20 @@
           @snow_phoenix
         </a>
       </div>
-      
+
       <small>&copy; 2025S Flashback First Aid Guide</small>
     </div>
-    
   </footer>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      var favoriteButtons = document.querySelectorAll('.favorite-button');
-      var storageKey = 'favoriteTips';
-      var favorites = getStoredFavorites();
-
-      function getStoredFavorites() {
-        try {
-          var stored = window.localStorage.getItem(storageKey);
-
-          if (!stored) {
-            return [];
-          }
-
-          var parsed = JSON.parse(stored);
-
-          if (!Array.isArray(parsed)) {
-            return [];
-          }
-
-          var sanitized = parsed.filter(function (item) {
-            return typeof item === 'string' && item;
-          });
-
-          if (sanitized.length !== parsed.length) {
-            try {
-              window.localStorage.setItem(storageKey, JSON.stringify(sanitized));
-            } catch (storageError) {
-              // ignore cleanup failure
-            }
-          }
-
-          return sanitized;
-        } catch (error) {
-          return [];
-        }
-      }
-
-      function saveFavorites() {
-        try {
-          window.localStorage.setItem(storageKey, JSON.stringify(favorites));
-        } catch (error) {
-          // localStorageが利用できない場合は永続化をスキップ
-        }
-      }
-
-      function setButtonState(button, isFavorite) {
-        button.setAttribute('aria-pressed', String(isFavorite));
-
-        if (button.dataset.labelAdd && button.dataset.labelRemove) {
-          button.setAttribute(
-            'aria-label',
-            isFavorite ? button.dataset.labelRemove : button.dataset.labelAdd
-          );
-        }
-
-        var srText = button.querySelector('.sr-only');
-        if (srText) {
-          srText.textContent = isFavorite ? 'お気に入りを解除' : 'お気に入りに追加';
-        }
-      }
-
-      function addFavorite(id) {
-        if (id && favorites.indexOf(id) === -1) {
-          favorites.push(id);
-          saveFavorites();
-        }
-      }
-
-      function removeFavorite(id) {
-        var index = favorites.indexOf(id);
-
-        if (index !== -1) {
-          favorites.splice(index, 1);
-          saveFavorites();
-        }
-      }
-
-      favoriteButtons.forEach(function (button) {
-        var listItem = button.closest('li');
-        var heading = listItem ? listItem.querySelector('h3') : null;
-        var tipNumber = listItem ? listItem.querySelector('.tip-number') : null;
-        var title = heading ? heading.textContent.trim() : '';
-        var tipNumberValue = tipNumber ? tipNumber.textContent.trim() : '';
-        var identifier = '';
-
-        if (tipNumberValue && title) {
-          identifier = tipNumberValue + ':' + title;
-        } else if (title) {
-          identifier = title;
-        } else {
-          identifier = tipNumberValue;
-        }
-
-        identifier = identifier ? identifier.trim() : '';
-        button.dataset.favoriteId = identifier;
-
-        if (title) {
-          var labelAdd = '「' + title + '」をお気に入りに追加';
-          var labelRemove = '「' + title + '」のお気に入りを解除';
-          button.dataset.labelAdd = labelAdd;
-          button.dataset.labelRemove = labelRemove;
-        }
-
-        var isInitiallyFavorite = identifier && favorites.indexOf(identifier) !== -1;
-        setButtonState(button, isInitiallyFavorite);
-
-        button.addEventListener('click', function () {
-          var isPressed = button.getAttribute('aria-pressed') === 'true';
-          var nextState = !isPressed;
-
-          setButtonState(button, nextState);
-
-          var favoriteId = button.dataset.favoriteId;
-
-          if (favoriteId) {
-            if (nextState) {
-              addFavorite(favoriteId);
-            } else {
-              removeFavorite(favoriteId);
-            }
-          }
-        });
-      });
-    });
-  </script>
+  <noscript>
+    <p class="noscript-message">JavaScriptを有効にすると、お気に入りの保存やページ先頭に戻るボタンが利用できます。</p>
+  </noscript>
 
   <button type="button" id="backToTop" class="back-to-top" aria-label="ページの先頭へ戻る">
     <span aria-hidden="true">▲</span>
     <span class="visually-hidden">ページの先頭へ戻る</span>
   </button>
 
-  <script>
-    (function () {
-      const backToTopButton = document.getElementById('backToTop');
-      if (!backToTopButton) return;
-
-      const prefersReducedMotionQuery = typeof window.matchMedia === 'function'
-        ? window.matchMedia('(prefers-reduced-motion: reduce)')
-        : null;
-
-      const toggleVisibility = () => {
-        if (window.scrollY > 240) {
-          backToTopButton.classList.add('is-visible');
-        } else {
-          backToTopButton.classList.remove('is-visible');
-        }
-      };
-
-      window.addEventListener('scroll', toggleVisibility, { passive: true });
-      toggleVisibility();
-
-      backToTopButton.addEventListener('click', () => {
-        const prefersReducedMotion = prefersReducedMotionQuery && prefersReducedMotionQuery.matches;
-        const scrollOptions = prefersReducedMotion ? { top: 0 } : { top: 0, behavior: 'smooth' };
-        window.scrollTo(scrollOptions);
-      });
-    })();
-  </script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,257 @@
+(() => {
+  'use strict';
+
+  const STORAGE_KEY = 'favoriteTips';
+  const HEART_PATH =
+    'M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41 0.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z';
+
+  const favorites = new Set(loadFavorites());
+  const buttonRegistry = new Map();
+
+  const init = () => {
+    initializeTips();
+    initializeBackToTop();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  function loadFavorites(serializedValue) {
+    if (typeof serializedValue === 'string') {
+      return parseFavorites(serializedValue);
+    }
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      return parseFavorites(stored);
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function parseFavorites(serialized) {
+    if (!serialized) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(serialized);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .filter((item) => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function persistFavorites() {
+    try {
+      const payload = JSON.stringify(Array.from(favorites).sort());
+      window.localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      // localStorageが利用できない場合は永続化をスキップ
+    }
+  }
+
+  function initializeTips() {
+    const tipLists = document.querySelectorAll('.tip-list');
+    if (!tipLists.length) {
+      return;
+    }
+
+    tipLists.forEach((list) => {
+      const startValue = Number.parseInt(list.getAttribute('start') || '1', 10) || 1;
+      const items = Array.from(list.querySelectorAll('li'));
+
+      items.forEach((item, index) => {
+        const number = startValue + index;
+        const paddedNumber = String(number).padStart(2, '0');
+
+        let numberBadge = item.querySelector('.tip-number');
+        if (!numberBadge) {
+          numberBadge = document.createElement('span');
+          numberBadge.className = 'tip-number';
+          numberBadge.setAttribute('aria-hidden', 'true');
+          const firstElement = item.firstElementChild;
+          item.insertBefore(numberBadge, firstElement);
+        }
+        numberBadge.textContent = paddedNumber;
+
+        if (!item.dataset.tipId) {
+          item.dataset.tipId = `tip-${paddedNumber}`;
+        }
+
+        if (!item.querySelector('.tip-content')) {
+          const firstDiv = item.querySelector('div');
+          if (firstDiv) {
+            firstDiv.classList.add('tip-content');
+          }
+        }
+
+        const heading = item.querySelector('h3');
+        const tipTitle = heading ? heading.textContent.trim() : `ヒント${paddedNumber}`;
+        const tipId = item.dataset.tipId;
+
+        let button = item.querySelector('.favorite-button');
+        if (!button) {
+          button = createFavoriteButton(tipId, tipTitle);
+          item.appendChild(button);
+        } else {
+          prepareExistingButton(button, tipId, tipTitle);
+        }
+      });
+    });
+
+    window.addEventListener('storage', (event) => {
+      if (event.key !== STORAGE_KEY) {
+        return;
+      }
+
+      const latestFavorites = new Set(loadFavorites(event.newValue));
+      favorites.clear();
+      latestFavorites.forEach((value) => favorites.add(value));
+
+      buttonRegistry.forEach((button, id) => {
+        updateButtonState(button, favorites.has(id));
+      });
+    });
+  }
+
+  function prepareExistingButton(button, tipId, tipTitle) {
+    button.classList.add('favorite-button');
+    button.type = 'button';
+    button.dataset.favoriteId = tipId;
+    button.dataset.labelAdd = `「${tipTitle}」をお気に入りに追加`;
+    button.dataset.labelRemove = `「${tipTitle}」のお気に入りを解除`;
+
+    let srText = button.querySelector('.visually-hidden');
+    if (!srText) {
+      srText = document.createElement('span');
+      srText.className = 'visually-hidden';
+      button.insertBefore(srText, button.firstChild);
+    }
+
+    let heartIcon = button.querySelector('.heart-icon');
+    if (!heartIcon) {
+      heartIcon = createHeartIcon();
+      button.appendChild(heartIcon);
+    }
+
+    buttonRegistry.set(tipId, button);
+    updateButtonState(button, favorites.has(tipId));
+
+    button.addEventListener('click', () => {
+      toggleFavorite(tipId);
+    });
+  }
+
+  function createFavoriteButton(tipId, tipTitle) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'favorite-button';
+    button.dataset.favoriteId = tipId;
+    button.dataset.labelAdd = `「${tipTitle}」をお気に入りに追加`;
+    button.dataset.labelRemove = `「${tipTitle}」のお気に入りを解除`;
+
+    const srText = document.createElement('span');
+    srText.className = 'visually-hidden';
+    button.appendChild(srText);
+
+    const icon = createHeartIcon();
+    button.appendChild(icon);
+
+    buttonRegistry.set(tipId, button);
+    updateButtonState(button, favorites.has(tipId));
+
+    button.addEventListener('click', () => {
+      toggleFavorite(tipId);
+    });
+
+    return button;
+  }
+
+  function createHeartIcon() {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.classList.add('heart-icon');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('aria-hidden', 'true');
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', HEART_PATH);
+    svg.appendChild(path);
+
+    return svg;
+  }
+
+  function toggleFavorite(tipId) {
+    const currentlyFavorite = favorites.has(tipId);
+
+    if (currentlyFavorite) {
+      favorites.delete(tipId);
+    } else {
+      favorites.add(tipId);
+    }
+
+    buttonRegistry.forEach((button, id) => {
+      if (id === tipId) {
+        updateButtonState(button, !currentlyFavorite);
+      }
+    });
+
+    persistFavorites();
+  }
+
+  function updateButtonState(button, isFavorite) {
+    button.setAttribute('aria-pressed', String(isFavorite));
+    const label = isFavorite ? button.dataset.labelRemove : button.dataset.labelAdd;
+
+    if (label) {
+      button.setAttribute('aria-label', label);
+      button.setAttribute('title', label);
+    }
+
+    const srText = button.querySelector('.visually-hidden');
+    if (srText) {
+      srText.textContent = isFavorite ? 'お気に入りを解除' : 'お気に入りに追加';
+    }
+  }
+
+  function initializeBackToTop() {
+    const backToTopButton = document.getElementById('backToTop');
+    if (!backToTopButton) {
+      return;
+    }
+
+    const prefersReducedMotionQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+
+    const toggleVisibility = () => {
+      if (window.scrollY > 240) {
+        backToTopButton.classList.add('is-visible');
+      } else {
+        backToTopButton.classList.remove('is-visible');
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility, { passive: true });
+    toggleVisibility();
+
+    backToTopButton.addEventListener('click', () => {
+      const prefersReducedMotion = Boolean(
+        prefersReducedMotionQuery && prefersReducedMotionQuery.matches
+      );
+      const scrollOptions = prefersReducedMotion ? { top: 0 } : { top: 0, behavior: 'smooth' };
+      window.scrollTo(scrollOptions);
+    });
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -42,19 +42,6 @@ img {
   display: block;
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
 .inner {
   width: min(1100px, 90vw);
   margin: 0 auto;
@@ -273,8 +260,12 @@ section {
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.tip-list li > div {
+.tip-content {
   min-width: 0;
+}
+
+.tip-content p {
+  margin-top: 0.45rem;
 }
 
 .tip-list li:hover,
@@ -396,6 +387,18 @@ section {
 .site-footer small {
   display: block;
   margin-top: 0.5rem;
+}
+
+.noscript-message {
+  margin: 1rem auto 0;
+  max-width: min(780px, 90vw);
+  padding: 0.75rem 1rem;
+  background: rgba(237, 122, 122, 0.12);
+  border: 1px solid rgba(237, 122, 122, 0.3);
+  border-radius: 14px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
 }
 
 .back-to-top {


### PR DESCRIPTION
## Summary
- convert the tip sections to ordered lists with data attributes and a JavaScript-driven favorite button
- move the favorite/back-to-top behaviour into a new `main.js` module that hardens localStorage handling and updates labels consistently
- adjust styles to target the new `.tip-content` wrapper and add a styled `<noscript>` notice for degraded functionality

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_e_68cf9834bfa4832695636bcbc8b79984