### PR TITLE
Add trigger log recording page with local storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
       </p>
       <h1>フラッシュバック<br>応急対処ガイド</h1>
       <p class="lead">記憶の波に飲み込まれそうになった瞬間に、「今ここ」に戻るための50のアイデア。<br>専門的な治療を補う、日常のセルフケアとしてご活用ください。</p>
+      <div class="trigger-log-link-wrapper">
+        <a class="trigger-log-link" href="trigger-log.html">トリガーを記録する</a>
+      </div>
     </div>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,9 @@
   --card-border: rgba(255, 255, 255, 0.6);
   --accent: #ed7a7a;
   --accent-soft: #f6b6aa;
+  --accent-green: #62bba1;
+  --accent-green-deep: #3b8d72;
+  --accent-green-soft: #e0f4ec;
   --text-main: #3a3a3a;
   --text-muted: #6e6e6e;
   --heading-font: 'Playfair Display', 'Times New Roman', serif;
@@ -387,6 +390,41 @@ section {
 .site-footer small {
   display: block;
   margin-top: 0.5rem;
+}
+
+.trigger-log-link-wrapper {
+  margin-top: 1.8rem;
+}
+
+.trigger-log-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent-green), var(--accent-green-deep));
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1rem;
+  box-shadow: 0 14px 30px rgba(98, 187, 161, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.trigger-log-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(59, 141, 114, 0.32);
+}
+
+.trigger-log-link:focus-visible {
+  outline: 3px solid rgba(98, 187, 161, 0.35);
+  outline-offset: 3px;
+}
+
+.trigger-log-link:active {
+  transform: translateY(0);
+  box-shadow: 0 10px 22px rgba(59, 141, 114, 0.28);
 }
 
 .noscript-message {

--- a/trigger-log.css
+++ b/trigger-log.css
@@ -1,0 +1,442 @@
+body.trigger-log-page {
+  --bg-gradient: linear-gradient(135deg, #f4fbf7 0%, #e8f5ee 100%);
+  --card-bg: rgba(255, 255, 255, 0.9);
+  --card-border: rgba(205, 232, 219, 0.82);
+  --accent: var(--accent-green);
+  --accent-soft: var(--accent-green-soft);
+  --shadow-soft: 0 22px 44px rgba(119, 180, 156, 0.2);
+  --shadow-card: 0 20px 38px rgba(136, 190, 164, 0.18);
+}
+
+body.trigger-log-page .site-header {
+  background: radial-gradient(circle at 25% 20%, rgba(255, 255, 255, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.4), transparent 60%),
+    linear-gradient(140deg, rgba(147, 214, 189, 0.7), rgba(183, 228, 206, 0.6));
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5);
+}
+
+body.trigger-log-page .bandage-icon .bandage-base {
+  fill: var(--accent);
+}
+
+body.trigger-log-page .bandage-icon .bandage-center {
+  fill: #dff3ea;
+}
+
+body.trigger-log-page .bandage-icon .bandage-hole {
+  fill: var(--accent);
+}
+
+.log-header .lead {
+  max-width: 520px;
+  margin-bottom: 1.6rem;
+}
+
+.log-back-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.6rem 1.35rem;
+  border-radius: 999px;
+  border: 1px solid rgba(98, 187, 161, 0.4);
+  background: rgba(98, 187, 161, 0.15);
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.log-back-link:hover {
+  background: rgba(98, 187, 161, 0.25);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(98, 187, 161, 0.22);
+}
+
+.log-back-link:focus-visible {
+  outline: 3px solid rgba(98, 187, 161, 0.35);
+  outline-offset: 3px;
+}
+
+.log-main {
+  padding-bottom: 4rem;
+}
+
+.log-section .inner {
+  position: relative;
+}
+
+.log-card {
+  position: relative;
+  z-index: 1;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 28px;
+  padding: clamp(1.8rem, 4vw, 2.5rem) clamp(1.6rem, 5vw, 2.8rem);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+}
+
+.log-card__header h2 {
+  margin: 0;
+  font-size: clamp(1.45rem, 2.6vw, 1.8rem);
+  font-weight: 700;
+}
+
+.log-card__header p {
+  margin: 0.65rem 0 0;
+  color: var(--text-muted);
+  line-height: 1.65;
+}
+
+.trigger-form {
+  display: grid;
+  gap: 2rem;
+  margin-top: 1.8rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.field-heading h3 {
+  margin: 0;
+  font-size: 1.18rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+}
+
+.field-required,
+.field-optional {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.field-required {
+  color: var(--accent);
+}
+
+.field-optional {
+  color: var(--text-muted);
+}
+
+.field-description {
+  margin: 0.2rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.field-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  padding: 0.55rem;
+  border-radius: 18px;
+  background: rgba(98, 187, 161, 0.08);
+  border: 1px solid rgba(98, 187, 161, 0.18);
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.6rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid rgba(98, 187, 161, 0.2);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.tag-chip:hover {
+  background: rgba(98, 187, 161, 0.15);
+  border-color: rgba(98, 187, 161, 0.3);
+}
+
+.tag-chip:focus-visible {
+  outline: 3px solid rgba(98, 187, 161, 0.35);
+  outline-offset: 3px;
+}
+
+.tag-chip.is-selected {
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(98, 187, 161, 0.32);
+}
+
+.tag-chip.is-selected:hover {
+  transform: translateY(-1px);
+}
+
+.tag-chips.is-invalid {
+  border-color: rgba(208, 97, 95, 0.55);
+  box-shadow: 0 0 0 3px rgba(208, 97, 95, 0.18);
+}
+
+.other-input {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.8rem 1rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(98, 187, 161, 0.18);
+}
+
+.input-with-counter {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.trigger-form textarea,
+.trigger-form input[type="text"] {
+  width: 100%;
+  font: inherit;
+  border-radius: 16px;
+  border: 1px solid rgba(98, 187, 161, 0.28);
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  color: var(--text-main);
+}
+
+.trigger-form textarea {
+  min-height: 150px;
+  resize: vertical;
+}
+
+.trigger-form textarea:focus-visible,
+.trigger-form input[type="text"]:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(98, 187, 161, 0.25);
+  background: #fff;
+}
+
+.trigger-form textarea.is-invalid,
+.trigger-form input[type="text"].is-invalid {
+  border-color: rgba(208, 97, 95, 0.65);
+  box-shadow: 0 0 0 3px rgba(208, 97, 95, 0.18);
+}
+
+.char-count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.field-error {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #d0615f;
+  min-height: 1.2em;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.log-submit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.95rem 2.6rem;
+  border-radius: 999px;
+  border: none;
+  font: inherit;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  box-shadow: 0 18px 36px rgba(98, 187, 161, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.log-submit-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 40px rgba(59, 141, 114, 0.35);
+}
+
+.log-submit-button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 28px rgba(59, 141, 114, 0.28);
+}
+
+.log-submit-button:focus-visible {
+  outline: 3px solid rgba(98, 187, 161, 0.35);
+  outline-offset: 3px;
+}
+
+.form-feedback {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+  min-height: 1.3em;
+}
+
+.form-feedback.is-error {
+  color: #d0615f;
+}
+
+.text-button {
+  border: none;
+  background: none;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.text-button:hover {
+  background: rgba(98, 187, 161, 0.15);
+}
+
+.text-button:focus-visible {
+  outline: 3px solid rgba(98, 187, 161, 0.35);
+  outline-offset: 2px;
+}
+
+.log-history__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.log-history__description {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted);
+}
+
+.log-empty-message {
+  margin: 1.8rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.log-empty-message.is-hidden {
+  display: none !important;
+}
+
+.log-list {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.log-entry {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(98, 187, 161, 0.18);
+  border-radius: 22px;
+  padding: 1.5rem;
+  box-shadow: 0 14px 30px rgba(98, 187, 161, 0.16);
+}
+
+.log-entry__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.log-entry__timestamp {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.log-entry__body {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.log-entry__group h3 {
+  margin: 0 0 0.55rem;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.log-entry__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.log-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(98, 187, 161, 0.14);
+  color: var(--accent);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.log-chip--other {
+  background: rgba(98, 187, 161, 0.24);
+}
+
+.log-entry__details {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  background: rgba(98, 187, 161, 0.1);
+  border-radius: 18px;
+  color: var(--text-main);
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .log-card {
+    padding: 1.6rem 1.4rem;
+  }
+
+  .log-history__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .form-actions {
+    justify-content: stretch;
+  }
+
+  .log-submit-button {
+    width: 100%;
+  }
+
+  .log-entry {
+    padding: 1.3rem;
+  }
+}

--- a/trigger-log.html
+++ b/trigger-log.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="フラッシュバック時に感じたトリガーや感情を素早く記録できるフォーム。記録は端末にのみ保存されます。">
+  <title>フラッシュバック・トリガー記録</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="trigger-log.css">
+</head>
+<body class="trigger-log-page">
+  <header class="site-header log-header">
+    <div class="inner">
+      <p class="eyebrow" aria-label="Trigger Log">
+        <span class="eyebrow-icon" aria-hidden="true">
+          <svg class="bandage-icon" viewBox="0 0 64 24" role="presentation" focusable="false">
+            <rect class="bandage-base" x="4" y="6" width="56" height="12" rx="6"></rect>
+            <rect class="bandage-center" x="22" y="4" width="20" height="16" rx="5"></rect>
+            <circle class="bandage-hole" cx="28" cy="12" r="1.4"></circle>
+            <circle class="bandage-hole" cx="32" cy="12" r="1.4"></circle>
+            <circle class="bandage-hole" cx="36" cy="12" r="1.4"></circle>
+          </svg>
+        </span>
+        <span class="eyebrow-label">Trigger Log</span>
+      </p>
+      <h1>フラッシュバック・トリガー記録</h1>
+      <p class="lead">いま感じたこと、ちょっとだけ残そう。</p>
+      <a class="log-back-link" href="index.html">ガイドに戻る</a>
+    </div>
+  </header>
+
+  <main class="log-main">
+    <section class="log-section">
+      <div class="inner">
+        <div class="log-card log-card--form">
+          <div class="log-card__header">
+            <h2>トリガー記録フォーム</h2>
+            <p>心にひっかかった出来事を数タップでメモできます。入力内容はお使いの端末にのみ保存されます。</p>
+          </div>
+          <form id="trigger-log-form" class="trigger-form" novalidate>
+            <div class="form-field" data-field="trigger">
+              <div class="field-heading">
+                <h3>トリガー <span class="field-required">必須</span></h3>
+                <p class="field-description">当てはまるものを選択。複数選べます。</p>
+              </div>
+              <div class="tag-chips" data-tag-group="trigger" data-required="true">
+                <button type="button" class="tag-chip" data-value="sound" data-label="🔊 大きな音" aria-pressed="false">🔊 大きな音</button>
+                <button type="button" class="tag-chip" data-value="smell" data-label="👃 匂い" aria-pressed="false">👃 匂い</button>
+                <button type="button" class="tag-chip" data-value="gaze" data-label="👀 視線" aria-pressed="false">👀 視線</button>
+                <button type="button" class="tag-chip" data-value="words" data-label="🗣 言葉" aria-pressed="false">🗣 言葉</button>
+                <button type="button" class="tag-chip" data-value="person" data-label="👤 人" aria-pressed="false">👤 人</button>
+                <button type="button" class="tag-chip" data-value="place" data-label="📍 場所・環境" aria-pressed="false">📍 場所・環境</button>
+                <button type="button" class="tag-chip" data-value="unknown" data-label="❓ わからない" aria-pressed="false">❓ わからない</button>
+                <button type="button" class="tag-chip tag-chip--other" data-value="other" data-label="✍ その他" data-controls="trigger-other-field" aria-pressed="false" aria-expanded="false">✍ その他</button>
+              </div>
+              <p class="field-error" data-error-target="trigger" aria-live="polite"></p>
+              <div class="other-input" id="trigger-other-field" data-other-field="trigger" hidden>
+                <label for="trigger-other">その他の内容（1〜40文字）</label>
+                <div class="input-with-counter">
+                  <input type="text" id="trigger-other" name="triggerOther" inputmode="text" autocomplete="off" maxlength="40" data-maxlength="40">
+                  <span class="char-count" data-count-for="trigger-other">0 / 40</span>
+                </div>
+                <p class="field-error" data-error-target="trigger-other" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="form-field">
+              <div class="field-heading">
+                <h3>詳細 <span class="field-optional">任意</span></h3>
+              </div>
+              <textarea id="trigger-details" name="details" rows="5" maxlength="1000" placeholder="何が起きたか／自分に起きた反応などをメモ（任意）"></textarea>
+              <div class="field-footer">
+                <span class="char-count" data-count-for="trigger-details">0 / 1000</span>
+              </div>
+              <p class="field-error" data-error-target="trigger-details" aria-live="polite"></p>
+            </div>
+
+            <div class="form-field" data-field="emotion">
+              <div class="field-heading">
+                <h3>感情 <span class="field-optional">任意</span></h3>
+                <p class="field-description">浮かんだ感情があれば記録しておきましょう。</p>
+              </div>
+              <div class="tag-chips" data-tag-group="emotion">
+                <button type="button" class="tag-chip" data-value="anger" data-label="😠 怒り" aria-pressed="false">😠 怒り</button>
+                <button type="button" class="tag-chip" data-value="sadness" data-label="😢 悲しみ" aria-pressed="false">😢 悲しみ</button>
+                <button type="button" class="tag-chip" data-value="anxiety" data-label="😰 不安" aria-pressed="false">😰 不安</button>
+                <button type="button" class="tag-chip" data-value="numb" data-label="😶 無感覚" aria-pressed="false">😶 無感覚</button>
+                <button type="button" class="tag-chip tag-chip--other" data-value="other" data-label="✍ その他" data-controls="emotion-other-field" aria-pressed="false" aria-expanded="false">✍ その他</button>
+              </div>
+              <div class="other-input" id="emotion-other-field" data-other-field="emotion" hidden>
+                <label for="emotion-other">そのほかの感情（1〜40文字）</label>
+                <div class="input-with-counter">
+                  <input type="text" id="emotion-other" name="emotionOther" inputmode="text" autocomplete="off" maxlength="40" data-maxlength="40">
+                  <span class="char-count" data-count-for="emotion-other">0 / 40</span>
+                </div>
+                <p class="field-error" data-error-target="emotion-other" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="form-field" data-field="action">
+              <div class="field-heading">
+                <h3>行動 <span class="field-optional">任意</span></h3>
+                <p class="field-description">そのときの反応や行動をメモ。</p>
+              </div>
+              <div class="tag-chips" data-tag-group="action">
+                <button type="button" class="tag-chip" data-value="freeze" data-label="🪨 固まった" aria-pressed="false">🪨 固まった</button>
+                <button type="button" class="tag-chip" data-value="cry" data-label="😭 泣いた" aria-pressed="false">😭 泣いた</button>
+                <button type="button" class="tag-chip" data-value="anger" data-label="⚡ 怒った" aria-pressed="false">⚡ 怒った</button>
+                <button type="button" class="tag-chip" data-value="avoid" data-label="↩️ 回避した" aria-pressed="false">↩️ 回避した</button>
+                <button type="button" class="tag-chip tag-chip--other" data-value="other" data-label="✍ その他" data-controls="action-other-field" aria-pressed="false" aria-expanded="false">✍ その他</button>
+              </div>
+              <div class="other-input" id="action-other-field" data-other-field="action" hidden>
+                <label for="action-other">そのほかの行動（1〜40文字）</label>
+                <div class="input-with-counter">
+                  <input type="text" id="action-other" name="actionOther" inputmode="text" autocomplete="off" maxlength="40" data-maxlength="40">
+                  <span class="char-count" data-count-for="action-other">0 / 40</span>
+                </div>
+                <p class="field-error" data-error-target="action-other" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="form-actions">
+              <button type="submit" class="log-submit-button">記録する</button>
+            </div>
+            <p class="form-feedback" id="form-feedback" aria-live="polite"></p>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="log-section">
+      <div class="inner">
+        <div class="log-card log-card--history">
+          <div class="log-card__header log-history__header">
+            <h2>記録一覧</h2>
+            <button type="button" class="text-button log-clear-button" data-action="clear-logs">すべて削除</button>
+          </div>
+          <p class="log-history__description">あとで見返したいときに、ここから確認できます。データは端末内に保存されます。</p>
+          <p class="log-empty-message" data-empty-message>まだ記録がありません。</p>
+          <ol class="log-list" id="log-list" aria-live="polite" aria-label="保存したトリガー記録"></ol>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="trigger-log.js" defer></script>
+</body>
+</html>

--- a/trigger-log.js
+++ b/trigger-log.js
@@ -1,0 +1,609 @@
+(() => {
+  'use strict';
+
+  const STORAGE_KEY = 'triggerLogs';
+  let formFeedback = null;
+  let logList = null;
+  let emptyMessage = null;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  function init() {
+    const form = document.getElementById('trigger-log-form');
+    if (!form) {
+      return;
+    }
+
+    formFeedback = document.getElementById('form-feedback');
+    logList = document.getElementById('log-list');
+    emptyMessage = document.querySelector('[data-empty-message]');
+
+    initializeTagGroups();
+    initializeCharCounters(form);
+    renderLogs(loadLogs());
+
+    form.addEventListener('submit', (event) => handleSubmit(event, form));
+
+    const clearButton = document.querySelector('[data-action="clear-logs"]');
+    if (clearButton) {
+      clearButton.addEventListener('click', handleClearLogs);
+    }
+
+    if (logList) {
+      logList.addEventListener('click', handleLogListClick);
+    }
+  }
+
+  function initializeTagGroups() {
+    const groups = document.querySelectorAll('[data-tag-group]');
+    groups.forEach((group) => {
+      group.addEventListener('click', (event) => {
+        const button = event.target.closest('.tag-chip');
+        if (!button || !group.contains(button)) {
+          return;
+        }
+
+        event.preventDefault();
+
+        const shouldSelect = !button.classList.contains('is-selected');
+        button.classList.toggle('is-selected', shouldSelect);
+        button.setAttribute('aria-pressed', shouldSelect ? 'true' : 'false');
+
+        const groupName = group.dataset.tagGroup;
+        if (groupName) {
+          setGroupError(groupName, '');
+        }
+
+        if (button.dataset.controls) {
+          toggleOtherField(button, shouldSelect);
+        }
+      });
+    });
+  }
+
+  function toggleOtherField(button, shouldShow) {
+    const fieldId = button.dataset.controls;
+    if (!fieldId) {
+      return;
+    }
+
+    const field = document.getElementById(fieldId);
+    if (!field) {
+      return;
+    }
+
+    const input = field.querySelector('input[type="text"]');
+    button.setAttribute('aria-expanded', shouldShow ? 'true' : 'false');
+
+    if (shouldShow) {
+      field.hidden = false;
+      if (input) {
+        input.focus({ preventScroll: true });
+      }
+    } else {
+      field.hidden = true;
+      if (input) {
+        input.value = '';
+        updateCharCount(input);
+        setInputError(input, input.id, '');
+      }
+    }
+  }
+
+  function initializeCharCounters(form) {
+    const fields = form.querySelectorAll('textarea, input[type="text"]');
+    fields.forEach((field) => {
+      if (!field.id) {
+        return;
+      }
+
+      updateCharCount(field);
+
+      field.addEventListener('input', () => {
+        updateCharCount(field);
+
+        if (field.classList.contains('is-invalid')) {
+          const maxLength = getFieldMaxLength(field);
+          const trimmedLength = field.value.trim().length;
+          if (trimmedLength > 0 && field.value.length <= maxLength) {
+            setInputError(field, field.id, '');
+          }
+        }
+      });
+    });
+  }
+
+  function handleSubmit(event, form) {
+    event.preventDefault();
+
+    const triggerSelection = collectGroupSelection('trigger');
+    const emotionSelection = collectGroupSelection('emotion');
+    const actionSelection = collectGroupSelection('action');
+    const detailsField = form.querySelector('#trigger-details');
+    const detailsValue = detailsField ? detailsField.value.trim() : '';
+
+    let isValid = true;
+
+    if (!triggerSelection.labels.length && !(triggerSelection.otherSelected && triggerSelection.otherValue)) {
+      setGroupError('trigger', 'トリガーを1つ以上 選んでね');
+      isValid = false;
+    }
+
+    if (triggerSelection.otherSelected) {
+      isValid = validateOtherInput('trigger', triggerSelection.otherValue) && isValid;
+    }
+
+    if (emotionSelection.otherSelected) {
+      isValid = validateOtherInput('emotion', emotionSelection.otherValue) && isValid;
+    }
+
+    if (actionSelection.otherSelected) {
+      isValid = validateOtherInput('action', actionSelection.otherValue) && isValid;
+    }
+
+    if (detailsField && detailsField.value.length > getFieldMaxLength(detailsField)) {
+      detailsField.value = detailsField.value.slice(0, getFieldMaxLength(detailsField));
+      setInputError(detailsField, detailsField.id, '1000文字以内で入力してください');
+      isValid = false;
+    }
+
+    if (!isValid) {
+      showFeedback('入力内容をご確認ください。', true);
+      return;
+    }
+
+    const entry = {
+      id: generateEntryId(),
+      createdAt: new Date().toISOString(),
+      triggers: triggerSelection.labels,
+      triggerOther: triggerSelection.otherSelected ? triggerSelection.otherValue : '',
+      details: detailsValue,
+      emotions: emotionSelection.labels,
+      emotionOther: emotionSelection.otherSelected ? emotionSelection.otherValue : '',
+      actions: actionSelection.labels,
+      actionOther: actionSelection.otherSelected ? actionSelection.otherValue : '',
+    };
+
+    const logs = loadLogs();
+    const updatedLogs = [entry, ...logs];
+
+    if (!persistLogs(updatedLogs)) {
+      showFeedback('記録の保存に失敗しました。', true);
+      return;
+    }
+
+    renderLogs(updatedLogs);
+    showFeedback('記録したよ。深呼吸はどう？');
+    resetFormState(form);
+  }
+
+  function handleLogListClick(event) {
+    const button = event.target.closest('.log-entry__delete');
+    if (!button) {
+      return;
+    }
+
+    const entry = button.closest('.log-entry');
+    if (!entry || !entry.dataset.entryId) {
+      return;
+    }
+
+    const logs = loadLogs();
+    const updatedLogs = logs.filter((item) => item.id !== entry.dataset.entryId);
+
+    if (!persistLogs(updatedLogs)) {
+      showFeedback('削除に失敗しました。', true);
+      return;
+    }
+
+    renderLogs(updatedLogs);
+    showFeedback('記録を削除しました。');
+  }
+
+  function handleClearLogs() {
+    const logs = loadLogs();
+    if (!logs.length) {
+      showFeedback('保存されている記録はありません。');
+      return;
+    }
+
+    const confirmed = window.confirm('すべての記録を削除しますか？');
+    if (!confirmed) {
+      return;
+    }
+
+    if (!persistLogs([])) {
+      showFeedback('削除に失敗しました。', true);
+      return;
+    }
+
+    renderLogs([]);
+    showFeedback('すべての記録を削除しました。');
+  }
+
+  function collectGroupSelection(groupName) {
+    const group = document.querySelector(`[data-tag-group="${groupName}"]`);
+    const labels = [];
+    let otherSelected = false;
+    let otherValue = '';
+
+    if (!group) {
+      return { labels, otherSelected, otherValue };
+    }
+
+    const buttons = group.querySelectorAll('.tag-chip.is-selected');
+    buttons.forEach((button) => {
+      const value = button.dataset.value;
+      const label = (button.dataset.label || button.textContent || '').trim();
+      if (value === 'other') {
+        otherSelected = true;
+      } else if (label) {
+        labels.push(label);
+      }
+    });
+
+    const otherField = document.querySelector(`[data-other-field="${groupName}"]`);
+    if (otherField && !otherField.hidden) {
+      const input = otherField.querySelector('input[type="text"]');
+      if (input) {
+        otherValue = input.value.trim();
+      }
+    }
+
+    return { labels, otherSelected, otherValue };
+  }
+
+  function validateOtherInput(groupName, value) {
+    const field = document.querySelector(`[data-other-field="${groupName}"]`);
+    if (!field) {
+      return true;
+    }
+
+    const input = field.querySelector('input[type="text"]');
+    if (!input) {
+      return true;
+    }
+
+    const trimmedValue = value.trim();
+    const maxLength = getFieldMaxLength(input);
+    let valid = true;
+
+    if (!trimmedValue) {
+      setInputError(input, input.id, '1文字以上で入力してください');
+      valid = false;
+    } else if (trimmedValue.length > maxLength) {
+      setInputError(input, input.id, `${maxLength}文字以内で入力してください`);
+      valid = false;
+    } else {
+      setInputError(input, input.id, '');
+    }
+
+    return valid;
+  }
+
+  function setGroupError(groupName, message) {
+    const group = document.querySelector(`[data-tag-group="${groupName}"]`);
+    const errorTargets = document.querySelectorAll(`[data-error-target="${groupName}"]`);
+
+    errorTargets.forEach((element) => {
+      element.textContent = message;
+    });
+
+    if (!group) {
+      return;
+    }
+
+    const field = group.closest('.form-field');
+    if (message) {
+      group.classList.add('is-invalid');
+      if (field) {
+        field.classList.add('has-error');
+      }
+    } else {
+      group.classList.remove('is-invalid');
+      if (field && !field.querySelector('.is-invalid')) {
+        field.classList.remove('has-error');
+      }
+    }
+  }
+
+  function setInputError(input, targetName, message) {
+    if (!input || !targetName) {
+      return;
+    }
+
+    const errorTargets = document.querySelectorAll(`[data-error-target="${targetName}"]`);
+    errorTargets.forEach((element) => {
+      element.textContent = message;
+    });
+
+    if (message) {
+      input.classList.add('is-invalid');
+      const field = input.closest('.form-field');
+      if (field) {
+        field.classList.add('has-error');
+      }
+    } else {
+      input.classList.remove('is-invalid');
+      const field = input.closest('.form-field');
+      if (field && !field.querySelector('.is-invalid')) {
+        field.classList.remove('has-error');
+      }
+    }
+  }
+
+  function resetFormState(form) {
+    form.reset();
+
+    const tagButtons = form.querySelectorAll('.tag-chip');
+    tagButtons.forEach((button) => {
+      button.classList.remove('is-selected');
+      button.setAttribute('aria-pressed', 'false');
+      if (button.dataset.controls) {
+        button.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    const otherFields = form.querySelectorAll('[data-other-field]');
+    otherFields.forEach((field) => {
+      field.hidden = true;
+      const input = field.querySelector('input[type="text"]');
+      if (input) {
+        input.value = '';
+        setInputError(input, input.id, '');
+        updateCharCount(input);
+      }
+    });
+
+    const textAreas = form.querySelectorAll('textarea');
+    textAreas.forEach((textarea) => {
+      setInputError(textarea, textarea.id, '');
+      updateCharCount(textarea);
+    });
+
+    const groups = form.querySelectorAll('[data-tag-group]');
+    groups.forEach((group) => {
+      group.classList.remove('is-invalid');
+    });
+
+    form.querySelectorAll('[data-error-target]').forEach((element) => {
+      element.textContent = '';
+    });
+
+    form.querySelectorAll('.form-field').forEach((field) => {
+      field.classList.remove('has-error');
+    });
+  }
+
+  function renderLogs(logs) {
+    if (!logList) {
+      return;
+    }
+
+    logList.innerHTML = '';
+
+    if (!Array.isArray(logs) || logs.length === 0) {
+      if (emptyMessage) {
+        emptyMessage.classList.remove('is-hidden');
+      }
+      return;
+    }
+
+    if (emptyMessage) {
+      emptyMessage.classList.add('is-hidden');
+    }
+
+    logs.forEach((entry) => {
+      const listItem = document.createElement('li');
+      listItem.className = 'log-entry';
+      if (typeof entry.id === 'string') {
+        listItem.dataset.entryId = entry.id;
+      }
+
+      const header = document.createElement('div');
+      header.className = 'log-entry__header';
+
+      const timeElement = document.createElement('time');
+      timeElement.className = 'log-entry__timestamp';
+      if (entry.createdAt) {
+        timeElement.dateTime = entry.createdAt;
+      }
+      timeElement.textContent = formatDateTime(entry.createdAt);
+      header.appendChild(timeElement);
+
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'text-button log-entry__delete';
+      deleteButton.textContent = '削除';
+      header.appendChild(deleteButton);
+
+      listItem.appendChild(header);
+
+      const body = document.createElement('div');
+      body.className = 'log-entry__body';
+
+      const triggerGroup = createChipsGroup('トリガー', entry.triggers, entry.triggerOther, true);
+      if (triggerGroup) {
+        body.appendChild(triggerGroup);
+      }
+
+      if (entry.details) {
+        const detailGroup = document.createElement('div');
+        detailGroup.className = 'log-entry__group';
+        const heading = document.createElement('h3');
+        heading.textContent = '詳細';
+        detailGroup.appendChild(heading);
+
+        const paragraph = document.createElement('p');
+        paragraph.className = 'log-entry__details';
+        paragraph.textContent = entry.details;
+        detailGroup.appendChild(paragraph);
+        body.appendChild(detailGroup);
+      }
+
+      const emotionGroup = createChipsGroup('感情', entry.emotions, entry.emotionOther);
+      if (emotionGroup) {
+        body.appendChild(emotionGroup);
+      }
+
+      const actionGroup = createChipsGroup('行動', entry.actions, entry.actionOther);
+      if (actionGroup) {
+        body.appendChild(actionGroup);
+      }
+
+      listItem.appendChild(body);
+      logList.appendChild(listItem);
+    });
+  }
+
+  function createChipsGroup(title, labels, otherValue, alwaysShow) {
+    const effectiveLabels = Array.isArray(labels) ? labels.filter((label) => typeof label === 'string' && label.trim() !== '') : [];
+    const trimmedOther = typeof otherValue === 'string' ? otherValue.trim() : '';
+
+    if (!effectiveLabels.length && !trimmedOther && !alwaysShow) {
+      return null;
+    }
+
+    const group = document.createElement('div');
+    group.className = 'log-entry__group';
+
+    const heading = document.createElement('h3');
+    heading.textContent = title;
+    group.appendChild(heading);
+
+    const list = document.createElement('ul');
+    list.className = 'log-entry__chips';
+
+    effectiveLabels.forEach((label) => {
+      const item = document.createElement('li');
+      item.className = 'log-chip';
+      item.textContent = label;
+      list.appendChild(item);
+    });
+
+    if (trimmedOther) {
+      const item = document.createElement('li');
+      item.className = 'log-chip log-chip--other';
+      item.textContent = `✍ ${trimmedOther}`;
+      list.appendChild(item);
+    }
+
+    if (!list.children.length && alwaysShow) {
+      const item = document.createElement('li');
+      item.className = 'log-chip log-chip--other';
+      item.textContent = '記録なし';
+      list.appendChild(item);
+    }
+
+    group.appendChild(list);
+    return group;
+  }
+
+  function loadLogs() {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .map((entry) => sanitizeEntry(entry))
+        .filter((entry) => entry !== null);
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function sanitizeEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+      return null;
+    }
+
+    const sanitized = {
+      id: typeof entry.id === 'string' ? entry.id : generateEntryId(),
+      createdAt: typeof entry.createdAt === 'string' ? entry.createdAt : new Date().toISOString(),
+      triggers: Array.isArray(entry.triggers) ? entry.triggers.filter((item) => typeof item === 'string') : [],
+      triggerOther: typeof entry.triggerOther === 'string' ? entry.triggerOther : '',
+      details: typeof entry.details === 'string' ? entry.details : '',
+      emotions: Array.isArray(entry.emotions) ? entry.emotions.filter((item) => typeof item === 'string') : [],
+      emotionOther: typeof entry.emotionOther === 'string' ? entry.emotionOther : '',
+      actions: Array.isArray(entry.actions) ? entry.actions.filter((item) => typeof item === 'string') : [],
+      actionOther: typeof entry.actionOther === 'string' ? entry.actionOther : '',
+    };
+
+    return sanitized;
+  }
+
+  function persistLogs(logs) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function updateCharCount(field) {
+    const countTarget = document.querySelector(`[data-count-for="${field.id}"]`);
+    if (!countTarget) {
+      return;
+    }
+
+    const maxLength = getFieldMaxLength(field);
+    const currentLength = field.value.length;
+    countTarget.textContent = `${currentLength} / ${maxLength}`;
+  }
+
+  function getFieldMaxLength(field) {
+    if (field instanceof HTMLTextAreaElement || field instanceof HTMLInputElement) {
+      if (field.maxLength && field.maxLength > 0) {
+        return field.maxLength;
+      }
+    }
+    const maxAttr = field.getAttribute('data-maxlength');
+    const parsed = maxAttr ? Number.parseInt(maxAttr, 10) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1000;
+  }
+
+  function showFeedback(message, isError = false) {
+    if (!formFeedback) {
+      return;
+    }
+
+    formFeedback.textContent = message;
+    formFeedback.classList.toggle('is-error', Boolean(isError));
+  }
+
+  function formatDateTime(value) {
+    if (!value) {
+      return '';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+
+    return `${year}/${month}/${day} ${hours}:${minutes}`;
+  }
+
+  function generateEntryId() {
+    const random = Math.random().toString(16).slice(2);
+    return `log-${Date.now()}-${random}`;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a call-to-action in the main guide that links to a new trigger log page
- create a dedicated trigger log HTML page with green-accented styling and form controls for recording triggers, emotions, and actions
- implement page-specific CSS and JavaScript to manage pill-style tag selections, validation, and localStorage persistence with list and delete controls

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d17264d97483269f222b9af3630cc8