### PR TITLE
Add confirmation before deleting saved logs

### DIFF
--- a/trigger-log.css
+++ b/trigger-log.css
@@ -32,6 +32,15 @@ body.trigger-log-page .bandage-icon .bandage-hole {
   margin-bottom: 1.6rem;
 }
 
+.log-header__title-main,
+.log-header__title-sub {
+  display: block;
+}
+
+.log-header__title-sub {
+  margin-top: 0.25rem;
+}
+
 .log-back-link {
   display: inline-flex;
   align-items: center;
@@ -271,19 +280,19 @@ body.trigger-log-page .bandage-icon .bandage-hole {
   font-size: 1.05rem;
   color: #fff;
   cursor: pointer;
-  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
-  box-shadow: 0 18px 36px rgba(98, 187, 161, 0.35);
+  background: linear-gradient(135deg, var(--accent-green-deep), var(--accent));
+  box-shadow: 0 18px 40px rgba(59, 141, 114, 0.42);
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
 .log-submit-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 40px rgba(59, 141, 114, 0.35);
+  box-shadow: 0 24px 44px rgba(47, 117, 88, 0.45);
 }
 
 .log-submit-button:active {
   transform: translateY(0);
-  box-shadow: 0 12px 28px rgba(59, 141, 114, 0.28);
+  box-shadow: 0 14px 30px rgba(47, 117, 88, 0.35);
 }
 
 .log-submit-button:focus-visible {

--- a/trigger-log.html
+++ b/trigger-log.html
@@ -26,7 +26,10 @@
         </span>
         <span class="eyebrow-label">Trigger Log</span>
       </p>
-      <h1>フラッシュバック・トリガー記録</h1>
+      <h1 class="log-header__title" aria-label="フラッシュバック・トリガー記録">
+        <span class="log-header__title-main">フラッシュバック</span>
+        <span class="log-header__title-sub">トリガー記録</span>
+      </h1>
       <p class="lead">いま感じたこと、ちょっとだけ残そう。</p>
       <a class="log-back-link" href="index.html">ガイドに戻る</a>
     </div>

--- a/trigger-log.js
+++ b/trigger-log.js
@@ -287,6 +287,16 @@
       return;
     }
 
+    const timestampElement = entry.querySelector('.log-entry__timestamp');
+    const displayTime = timestampElement ? timestampElement.textContent.trim() : '';
+    const confirmMessage = displayTime
+      ? `${displayTime}の記録を削除しますか？\n削除すると元に戻せません。`
+      : 'この記録を削除しますか？\n削除すると元に戻せません。';
+    const confirmed = window.confirm(confirmMessage);
+    if (!confirmed) {
+      return;
+    }
+
     const entryId = entry.dataset.entryId;
     const logs = loadLogs();
     const updatedLogs = logs.filter((item) => item.id !== entryId);


### PR DESCRIPTION
## Summary
- prompt for confirmation when deleting an individual trigger log entry and include context in the message
- split the trigger log page title onto two lines so "フラッシュバック" appears on its own line
- darken the log submit button styling to improve contrast

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d18891a9dc8326803682e64a3a4d8b