### PR TITLE
Match trigger log button color in header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -110,22 +110,26 @@ img {
 }
 
 .quick-access__link--log {
-  background: rgba(237, 122, 122, 0.12);
-  color: var(--accent);
-  border-color: rgba(237, 122, 122, 0.28);
-  box-shadow: 0 8px 20px rgba(237, 122, 122, 0.18);
+  background: linear-gradient(135deg, var(--accent-green), var(--accent-green-deep));
+  color: #fff;
+  border-color: rgba(59, 141, 114, 0.65);
+  box-shadow: 0 8px 22px rgba(59, 141, 114, 0.28);
 }
 
 .quick-access__link--log .quick-access__icon {
-  color: inherit;
+  color: currentColor;
 }
 
 .quick-access__link--log:hover,
 .quick-access__link--log:focus-visible {
-  background: rgba(237, 122, 122, 0.18);
-  border-color: rgba(237, 122, 122, 0.4);
-  color: var(--accent);
-  box-shadow: 0 14px 28px rgba(237, 122, 122, 0.22);
+  background: linear-gradient(135deg, #6ed2b4, #2f7c62);
+  border-color: rgba(59, 141, 114, 0.78);
+  color: #fff;
+  box-shadow: 0 14px 30px rgba(59, 141, 114, 0.32);
+}
+
+.quick-access__link--log:focus-visible {
+  outline: 3px solid rgba(98, 187, 161, 0.45);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- restyle the header trigger log quick access link to use the same green gradient as the hero section button
- ensure icon, border, shadow, and focus outline harmonize with the updated green styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1ec0398188326abd7fbacfe712528