### PR TITLE
Add trauma treatment roadmap page

### DIFF
--- a/partials/quick-access.html
+++ b/partials/quick-access.html
@@ -9,6 +9,16 @@
       </span>
       <span class="quick-access__label">ガイドを見る</span>
     </a>
+    <a href="roadmap.html" class="quick-access__link quick-access__link--roadmap">
+      <span class="quick-access__icon" aria-hidden="true">
+        <svg class="quick-access__icon-svg" viewBox="0 0 24 24" role="presentation" focusable="false">
+          <path d="M8.5 3.4 3.5 5.6v15l5-2.2 7 2.2 5-2.2V3.4l-5 2.2-7-2.2Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+          <path d="m8.5 3.4.04 15m7.01-12.8V20.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="12" cy="11" r="1.8" fill="currentColor"></circle>
+        </svg>
+      </span>
+      <span class="quick-access__label">ロードマップ</span>
+    </a>
     <a href="trigger-log.html" class="quick-access__link quick-access__link--log" target="_blank" rel="noopener noreferrer">
       <span class="quick-access__icon" aria-hidden="true">
         <svg class="quick-access__icon-svg" viewBox="0 0 24 24" role="presentation" focusable="false">

--- a/roadmap.css
+++ b/roadmap.css
@@ -1,0 +1,280 @@
+.roadmap-header {
+  background: radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.65), transparent 55%),
+    radial-gradient(circle at 85% 10%, rgba(255, 255, 255, 0.4), transparent 60%),
+    linear-gradient(140deg, rgba(255, 184, 140, 0.6), rgba(180, 219, 206, 0.7));
+  padding: clamp(3.2rem, 7vw, 4.6rem) 0 clamp(2.3rem, 6vw, 3.2rem);
+  text-align: center;
+}
+
+.roadmap-header::after {
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.5), transparent 70%);
+}
+
+.roadmap-header__title {
+  font-family: var(--heading-font);
+  font-weight: 600;
+  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  letter-spacing: 0.05em;
+  margin: clamp(1rem, 4vw, 1.5rem) 0 0.6rem;
+  line-height: 1.15;
+}
+
+.roadmap-header__title span {
+  display: block;
+}
+
+.roadmap-header__lead {
+  margin: 0 auto;
+  max-width: 720px;
+  font-size: 1.05rem;
+  color: var(--text-muted);
+}
+
+.roadmap-main {
+  padding: clamp(2.4rem, 6vw, 3.8rem) 0 4rem;
+}
+
+.roadmap-intro .inner {
+  background: var(--card-bg);
+  border-radius: 28px;
+  padding: clamp(1.8rem, 5vw, 2.4rem) clamp(1.6rem, 4vw, 2.6rem);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: 1rem;
+}
+
+.roadmap-intro h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3.2vw, 1.8rem);
+}
+
+.roadmap-intro p {
+  margin: 0;
+}
+
+.roadmap-current-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(98, 187, 161, 0.16);
+  color: var(--accent-green-deep);
+  font-weight: 600;
+  width: fit-content;
+}
+
+.roadmap-current-status__label {
+  font-weight: 500;
+}
+
+[data-current-stage-label] {
+  font-weight: 700;
+}
+
+.roadmap-storage-warning {
+  margin-top: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(237, 122, 122, 0.18);
+  color: var(--accent);
+  font-size: 0.95rem;
+}
+
+.roadmap-section .inner {
+  display: grid;
+  gap: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.roadmap-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: clamp(1.6rem, 3.6vw, 2.4rem);
+}
+
+.roadmap-step {
+  position: relative;
+  padding: clamp(1.8rem, 3.6vw, 2.6rem);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.68);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.roadmap-step::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 6px;
+  background: linear-gradient(180deg, rgba(255, 138, 61, 0.9), rgba(255, 207, 174, 0.7));
+}
+
+.roadmap-step.is-current {
+  border-color: rgba(98, 187, 161, 0.55);
+  box-shadow: 0 20px 38px rgba(98, 187, 161, 0.26);
+  transform: translateY(-2px);
+}
+
+.roadmap-step.is-current::before {
+  background: linear-gradient(180deg, rgba(98, 187, 161, 1), rgba(183, 225, 210, 0.8));
+}
+
+.roadmap-step__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.roadmap-step__index {
+  font-family: var(--heading-font);
+  font-size: clamp(0.95rem, 2.2vw, 1.1rem);
+  letter-spacing: 0.32em;
+  color: var(--accent-orange);
+}
+
+.roadmap-step.is-current .roadmap-step__index {
+  color: var(--accent-green-deep);
+}
+
+.roadmap-step__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.65rem);
+  font-weight: 700;
+}
+
+.roadmap-step__description {
+  margin: 0 0 0.9rem;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.roadmap-step__focus-list {
+  list-style: none;
+  margin: 0 0 1.2rem;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.75rem;
+}
+
+.roadmap-step__focus-list li {
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.75);
+  font-size: 0.92rem;
+  color: var(--text-main);
+}
+
+.roadmap-step.is-current .roadmap-step__focus-list li {
+  border-color: rgba(98, 187, 161, 0.45);
+}
+
+.roadmap-step__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-bottom: 1.1rem;
+}
+
+.roadmap-step__mark {
+  padding: 0.55rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 138, 61, 0.45);
+  background: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+  color: var(--accent-orange-deep);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.roadmap-step__mark:hover,
+.roadmap-step__mark:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(255, 138, 61, 0.28);
+}
+
+.roadmap-step__mark:focus-visible {
+  outline: 3px solid rgba(255, 166, 110, 0.45);
+  outline-offset: 2px;
+}
+
+.roadmap-step__mark--current {
+  background: linear-gradient(135deg, var(--accent-green), var(--accent-green-deep));
+  color: #fff;
+  border-color: rgba(59, 141, 114, 0.65);
+  box-shadow: 0 14px 30px rgba(59, 141, 114, 0.32);
+}
+
+.roadmap-step__note {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.roadmap-step__note label {
+  font-weight: 600;
+}
+
+.roadmap-step__note textarea {
+  width: 100%;
+  min-height: 6.5rem;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+  font-family: var(--body-font);
+  font-size: 0.98rem;
+  line-height: 1.6;
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.roadmap-step__note textarea:focus {
+  border-color: rgba(98, 187, 161, 0.7);
+  box-shadow: 0 0 0 3px rgba(98, 187, 161, 0.2);
+  outline: none;
+}
+
+.roadmap-step__note-status {
+  min-height: 1.2em;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 720px) {
+  .roadmap-header__title {
+    font-size: clamp(2rem, 8vw, 2.6rem);
+  }
+
+  .roadmap-header__lead {
+    font-size: 0.98rem;
+  }
+
+  .roadmap-step {
+    padding: clamp(1.4rem, 6vw, 1.9rem);
+  }
+
+  .roadmap-step__focus-list li {
+    font-size: 0.88rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .roadmap-step__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .roadmap-step__mark {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/roadmap.html
+++ b/roadmap.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="トラウマ治療のプロセスを7つのステージで可視化したロードマップ。現在地の記録とステージごとのメモを保存できます。">
+  <title>トラウマ治療ロードマップ</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="roadmap.css">
+</head>
+<body class="roadmap-page">
+  <div data-include="partials/quick-access.html"></div>
+
+  <header id="top" class="site-header roadmap-header">
+    <div class="inner">
+      <p class="eyebrow" aria-label="Trauma Recovery Roadmap">
+        <span class="eyebrow-icon" aria-hidden="true">
+          <svg class="roadmap-header__icon" viewBox="0 0 64 64" role="presentation" focusable="false">
+            <path d="M20 10 6 16v38l14-6 20 6 18-7V9l-18 7-20-6Z" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"></path>
+            <path d="M20 10v38m18-31v38" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"></path>
+            <circle cx="32" cy="30" r="4.6" fill="currentColor"></circle>
+          </svg>
+        </span>
+        <span class="eyebrow-label">Trauma Recovery Roadmap</span>
+      </p>
+      <h1 class="roadmap-header__title">
+        <span>トラウマ治療</span>
+        <span>ロードマップ</span>
+      </h1>
+      <p class="roadmap-header__lead">治療の道のりを見通しながら、いまの位置と次の一歩を可視化するためのページです。進み方は人それぞれ。専門家と相談しながら、ご自身のペースで活用してください。</p>
+    </div>
+  </header>
+
+  <main class="roadmap-main">
+    <section class="roadmap-intro">
+      <div class="inner">
+        <h2>ロードマップの使い方</h2>
+        <p>各ステージに取り組みたいことをメモしたり、いまどこにいるかを記録できます。ボタンで現在地をマークすると、ブラウザのローカルストレージに保存され、ページを再読み込みしても保持されます。</p>
+        <p class="roadmap-current-status"><span class="roadmap-current-status__label">現在地:</span> <span data-current-stage-label aria-live="polite">未設定</span></p>
+        <p class="roadmap-storage-warning" data-storage-warning hidden>ブラウザーの設定により保存機能が利用できない場合があります。そのときはメモが端末に保持されない可能性があります。</p>
+      </div>
+    </section>
+
+    <section class="roadmap-section" aria-labelledby="roadmap-stages-heading">
+      <div class="inner">
+        <h2 id="roadmap-stages-heading" class="visually-hidden">トラウマ治療の7ステージ</h2>
+        <ol class="roadmap-list">
+          <li class="roadmap-step" data-stage-id="stage-1">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 01</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-1" data-stage-title>生活基盤の安定</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>心身が休める環境を整える段階。</strong> 投薬治療や食生活、睡眠リズムを整え、揺らぎを最小限にします。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>投薬治療</li>
+              <li>食生活改善</li>
+              <li>生活リズムを整える</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-1">「生活基盤の安定」のメモ</label>
+              <textarea id="roadmap-note-stage-1" data-stage-note="stage-1" placeholder="例：服薬リマインダーを設定する、睡眠記録をつける など"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+
+          <li class="roadmap-step" data-stage-id="stage-2">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 02</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-2" data-stage-title>心理教育</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>起きていることを理解する段階。</strong> トラウマ反応の仕組みを学び、「自分に起きていること」に言葉を与えます。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>トラウマ反応の理解</li>
+              <li>セルフモニタリング</li>
+              <li>安全計画の確認</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-2">「心理教育」のメモ</label>
+              <textarea id="roadmap-note-stage-2" data-stage-note="stage-2" placeholder="例：学んだこと、支援者と共有したいポイントなど"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+
+          <li class="roadmap-step" data-stage-id="stage-3">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 03</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-3" data-stage-title>トラウマ耐性スキルの獲得</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>感情の波に耐えられる力を育む段階。</strong> グラウンディングやセルフケアの引き出しを増やします。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>グラウンディング練習</li>
+              <li>安心できるリソースづくり</li>
+              <li>コーピングスキルの反復</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-3">「トラウマ耐性スキルの獲得」のメモ</label>
+              <textarea id="roadmap-note-stage-3" data-stage-note="stage-3" placeholder="例：役立ったスキル、練習したい場面など"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+
+          <li class="roadmap-step" data-stage-id="stage-4">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 04</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-4" data-stage-title>身体的アプローチによるトラウマ処理</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>身体感覚と安全につながり直す段階。</strong> 呼吸や動きを使い、体が溜め込んだ反応を少しずつ解きほぐします。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>身体感覚へのやさしい気づき</li>
+              <li>呼吸・動作を用いた段階的アプローチ</li>
+              <li>安全な範囲での身体リリース</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-4">「身体的アプローチによるトラウマ処理」のメモ</label>
+              <textarea id="roadmap-note-stage-4" data-stage-note="stage-4" placeholder="例：体調の変化、安心できた動きなど"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+
+          <li class="roadmap-step" data-stage-id="stage-5">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 05</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-5" data-stage-title>感情整理によるトラウマ処理</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>感情に寄り添い、必要な表現を探す段階。</strong> 感情を言語化し、安全な場での表出方法を整えます。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>感情のラベリングと共有</li>
+              <li>表現手段（書く・話す・アートなど）の活用</li>
+              <li>感情の波を落ち着かせる手順</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-5">「感情整理によるトラウマ処理」のメモ</label>
+              <textarea id="roadmap-note-stage-5" data-stage-note="stage-5" placeholder="例：表現してみたい方法、気づいた感情など"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+
+          <li class="roadmap-step" data-stage-id="stage-6">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 06</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-6" data-stage-title>自己の再構築</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>新しい自己像を育てる段階。</strong> 認知や対人スキルを見直し、安心できるつながり方を選び直します。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>認知の書き換え</li>
+              <li>脳内回路の再接続</li>
+              <li>境界線ワーク等の対人関係スキル</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-6">「自己の再構築」のメモ</label>
+              <textarea id="roadmap-note-stage-6" data-stage-note="stage-6" placeholder="例：書き換えたい思考、境界線ワークの気づきなど"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+
+          <li class="roadmap-step" data-stage-id="stage-7">
+            <div class="roadmap-step__header">
+              <span class="roadmap-step__index">STEP 07</span>
+              <h3 class="roadmap-step__title" id="roadmap-stage-7" data-stage-title>新しい生き方の確立</h3>
+            </div>
+            <p class="roadmap-step__description"><strong>築き上げた力を日常に広げる段階。</strong> 大切にしたい価値観を軸に、新しいライフスタイルを少しずつ定着させます。</p>
+            <ul class="roadmap-step__focus-list">
+              <li>価値観と目標の再確認</li>
+              <li>新しい行動パターンの試行</li>
+              <li>継続的なセルフケアの設計</li>
+            </ul>
+            <div class="roadmap-step__actions">
+              <button type="button" class="roadmap-step__mark" data-stage-action="mark" data-label-mark="ここにいるとマーク" data-label-current="現在地">
+                <span class="roadmap-step__mark-text">ここにいるとマーク</span>
+              </button>
+            </div>
+            <div class="roadmap-step__note">
+              <label for="roadmap-note-stage-7">「新しい生き方の確立」のメモ</label>
+              <textarea id="roadmap-note-stage-7" data-stage-note="stage-7" placeholder="例：実践してみたいこと、支えになった習慣など"></textarea>
+              <p class="roadmap-step__note-status" data-note-status aria-live="polite"></p>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <div data-include="partials/note.html"></div>
+  </main>
+
+  <div data-include="partials/site-footer.html"></div>
+  <div data-include="partials/back-to-top.html"></div>
+
+  <script src="component-loader.js" defer></script>
+  <script src="main.js" defer></script>
+  <script src="roadmap.js" defer></script>
+</body>
+</html>

--- a/roadmap.js
+++ b/roadmap.js
@@ -1,0 +1,240 @@
+(() => {
+  'use strict';
+
+  const CURRENT_STAGE_KEY = 'traumaRoadmapCurrentStage';
+  const NOTES_KEY = 'traumaRoadmapNotes';
+  const SAVE_DELAY = 500;
+
+  const storage = getStorage();
+  const stageElements = document.querySelectorAll('[data-stage-id]');
+
+  if (!stageElements.length) {
+    const warning = document.querySelector('[data-storage-warning]');
+    if (!storage && warning) {
+      warning.hidden = false;
+    }
+    return;
+  }
+
+  const stageInfo = new Map();
+  const noteStatusElements = new Map();
+
+  stageElements.forEach((element) => {
+    const stageId = element.dataset.stageId;
+    if (!stageId) {
+      return;
+    }
+
+    const titleElement = element.querySelector('[data-stage-title]');
+    const stageTitle = titleElement ? titleElement.textContent.trim() : stageId;
+
+    stageInfo.set(stageId, { element, title: stageTitle });
+
+    const statusElement = element.querySelector('[data-note-status]');
+    if (statusElement) {
+      statusElement.textContent = '';
+      noteStatusElements.set(stageId, statusElement);
+    }
+  });
+
+  const notesData = loadNotes();
+
+  stageInfo.forEach(({ element }, stageId) => {
+    const noteField = element.querySelector('[data-stage-note]');
+    if (!noteField) {
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(notesData, stageId)) {
+      noteField.value = notesData[stageId];
+    }
+  });
+
+  const noteTimers = new Map();
+  const stageStatusLabel = document.querySelector('[data-current-stage-label]');
+  if (stageStatusLabel && !stageStatusLabel.hasAttribute('aria-live')) {
+    stageStatusLabel.setAttribute('aria-live', 'polite');
+  }
+
+  let currentStageId = null;
+  const storedStageId = loadStage();
+  if (storedStageId && stageInfo.has(storedStageId)) {
+    currentStageId = storedStageId;
+  }
+
+  applyCurrentStage(currentStageId);
+
+  stageInfo.forEach(({ element }, stageId) => {
+    const markButton = element.querySelector('[data-stage-action="mark"]');
+    if (markButton) {
+      markButton.addEventListener('click', () => {
+        currentStageId = currentStageId === stageId ? null : stageId;
+        applyCurrentStage(currentStageId);
+        persistStage(currentStageId);
+      });
+    }
+
+    const noteField = element.querySelector('[data-stage-note]');
+    if (noteField) {
+      noteField.addEventListener('input', () => {
+        scheduleNoteSave(stageId, noteField.value);
+      });
+
+      noteField.addEventListener('blur', () => {
+        finalizeNoteSave(stageId, noteField.value);
+      });
+    }
+  });
+
+  const storageWarning = document.querySelector('[data-storage-warning]');
+  if (!storage && storageWarning) {
+    storageWarning.hidden = false;
+  }
+
+  function applyCurrentStage(stageId) {
+    const effectiveStageId = stageId && stageInfo.has(stageId) ? stageId : null;
+    currentStageId = effectiveStageId;
+
+    stageInfo.forEach(({ element, title }, id) => {
+      const isCurrent = id === effectiveStageId;
+      element.classList.toggle('is-current', isCurrent);
+
+      const markButton = element.querySelector('[data-stage-action="mark"]');
+      if (markButton) {
+        const defaultLabel = markButton.dataset.labelMark || 'ここにいるとマーク';
+        const currentLabel = markButton.dataset.labelCurrent || '現在地';
+        const labelTarget = markButton.querySelector('.roadmap-step__mark-text');
+        const text = isCurrent ? currentLabel : defaultLabel;
+
+        if (labelTarget) {
+          labelTarget.textContent = text;
+        } else {
+          markButton.textContent = text;
+        }
+
+        markButton.setAttribute('aria-pressed', String(isCurrent));
+        markButton.classList.toggle('roadmap-step__mark--current', isCurrent);
+      }
+
+      if (isCurrent && stageStatusLabel) {
+        stageStatusLabel.textContent = title;
+      }
+    });
+
+    if (stageStatusLabel && !effectiveStageId) {
+      stageStatusLabel.textContent = '未設定';
+    }
+  }
+
+  function scheduleNoteSave(stageId, value) {
+    showNoteStatus(stageId, '保存中…');
+    clearPending(stageId);
+
+    const timerId = window.setTimeout(() => {
+      saveNote(stageId, value);
+      showNoteStatus(stageId, '保存しました');
+      noteTimers.delete(stageId);
+    }, SAVE_DELAY);
+
+    noteTimers.set(stageId, timerId);
+  }
+
+  function finalizeNoteSave(stageId, value) {
+    clearPending(stageId);
+    saveNote(stageId, value);
+    showNoteStatus(stageId, '保存しました');
+  }
+
+  function clearPending(stageId) {
+    const timerId = noteTimers.get(stageId);
+    if (timerId === undefined) {
+      return;
+    }
+
+    window.clearTimeout(timerId);
+    noteTimers.delete(stageId);
+  }
+
+  function showNoteStatus(stageId, message) {
+    const statusElement = noteStatusElements.get(stageId);
+    if (!statusElement) {
+      return;
+    }
+
+    statusElement.textContent = message;
+  }
+
+  function saveNote(stageId, value) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      notesData[stageId] = value;
+    } else {
+      delete notesData[stageId];
+    }
+
+    persistNotes();
+  }
+
+  function persistStage(stageId) {
+    if (!storage) {
+      return;
+    }
+
+    if (stageId) {
+      storage.setItem(CURRENT_STAGE_KEY, stageId);
+    } else {
+      storage.removeItem(CURRENT_STAGE_KEY);
+    }
+  }
+
+  function persistNotes() {
+    if (!storage) {
+      return;
+    }
+
+    storage.setItem(NOTES_KEY, JSON.stringify(notesData));
+  }
+
+  function loadStage() {
+    if (!storage) {
+      return null;
+    }
+
+    const stored = storage.getItem(CURRENT_STAGE_KEY);
+    return stored || null;
+  }
+
+  function loadNotes() {
+    if (!storage) {
+      return {};
+    }
+
+    const stored = storage.getItem(NOTES_KEY);
+    if (!stored) {
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(stored);
+      if (parsed && typeof parsed === 'object') {
+        return parsed;
+      }
+    } catch (error) {
+      console.warn('保存されたメモの読み込みに失敗しました。データを初期化します。', error);
+    }
+
+    return {};
+  }
+
+  function getStorage() {
+    try {
+      const { localStorage } = window;
+      const testKey = '__roadmap_storage_test__';
+      localStorage.setItem(testKey, '1');
+      localStorage.removeItem(testKey);
+      return localStorage;
+    } catch (error) {
+      console.warn('ローカルストレージにアクセスできませんでした。', error);
+      return null;
+    }
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,29 @@ img {
   outline-offset: 3px;
 }
 
+.quick-access__link--roadmap {
+  background: linear-gradient(135deg, var(--accent-orange), var(--accent-orange-deep));
+  color: #fff;
+  border-color: rgba(255, 138, 61, 0.65);
+  box-shadow: 0 8px 22px rgba(255, 138, 61, 0.28);
+}
+
+.quick-access__link--roadmap .quick-access__icon {
+  color: currentColor;
+}
+
+.quick-access__link--roadmap:hover,
+.quick-access__link--roadmap:focus-visible {
+  background: linear-gradient(135deg, #ff9a5c, #ff6b1a);
+  border-color: rgba(255, 138, 61, 0.78);
+  color: #fff;
+  box-shadow: 0 14px 30px rgba(255, 138, 61, 0.32);
+}
+
+.quick-access__link--roadmap:focus-visible {
+  outline: 3px solid rgba(255, 166, 110, 0.45);
+}
+
 .quick-access__link--log {
   background: linear-gradient(135deg, var(--accent-green), var(--accent-green-deep));
   color: #fff;


### PR DESCRIPTION
## Summary
- add a dedicated roadmap.html page that visualizes the trauma recovery journey and links to shared partials
- support marking the current treatment stage and taking per-stage notes that persist to localStorage
- style the roadmap timeline and new quick-access link with dedicated CSS and JavaScript enhancements

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3a0df2ec0832696089416a821c13d