### PR TITLE
Add delivery progress component to roadmap intro

### DIFF
--- a/roadmap.css
+++ b/roadmap.css
@@ -54,6 +54,235 @@
   margin: 0;
 }
 
+.roadmap-delivery {
+  margin-top: clamp(1.4rem, 4vw, 2.1rem);
+  padding: clamp(1.6rem, 4.5vw, 2.4rem);
+  border-radius: 26px;
+  border: 1px solid rgba(98, 187, 161, 0.28);
+  background: linear-gradient(140deg, rgba(224, 244, 236, 0.95), rgba(255, 255, 255, 0.92));
+  box-shadow: 0 20px 40px rgba(98, 187, 161, 0.16);
+  display: grid;
+  gap: clamp(1rem, 3.4vw, 1.6rem);
+}
+
+.roadmap-delivery__header h3 {
+  margin: 0 0 0.3rem;
+  font-size: clamp(1.2rem, 3vw, 1.55rem);
+}
+
+.roadmap-delivery__header p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: clamp(0.9rem, 2.4vw, 1rem);
+}
+
+.roadmap-delivery__steps {
+  --icon-size: 44px;
+  --steps-padding: clamp(0.4rem, 3.5vw, 1.6rem);
+  list-style: none;
+  margin: 0;
+  padding: 0 var(--steps-padding) clamp(1rem, 3vw, 1.5rem);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(0.45rem, 2.4vw, 1rem);
+  position: relative;
+  overflow-x: auto;
+}
+
+.roadmap-delivery__steps::before {
+  content: '';
+  position: absolute;
+  top: calc(var(--icon-size) / 2);
+  left: calc(var(--steps-padding) + var(--icon-size) / 2);
+  right: calc(var(--steps-padding) + var(--icon-size) / 2);
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(98, 187, 161, 0.7) 0%,
+    rgba(98, 187, 161, 0.7) 50%,
+    rgba(166, 205, 189, 0.55) 50%,
+    rgba(166, 205, 189, 0.55) 100%
+  );
+  pointer-events: none;
+}
+
+.roadmap-delivery__steps::-webkit-scrollbar {
+  height: 6px;
+}
+
+.roadmap-delivery__steps::-webkit-scrollbar-thumb {
+  background: rgba(98, 187, 161, 0.35);
+  border-radius: 999px;
+}
+
+.roadmap-delivery__step {
+  flex: 1;
+  min-width: max(110px, 15%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  text-align: center;
+  position: relative;
+  color: var(--accent-green-deep);
+}
+
+.roadmap-delivery__step-icon {
+  width: var(--icon-size);
+  height: var(--icon-size);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.92);
+  border: 2px solid rgba(98, 187, 161, 0.32);
+  color: rgba(98, 187, 161, 0.5);
+  box-shadow: 0 12px 24px rgba(98, 187, 161, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.roadmap-delivery__step-icon svg {
+  width: 60%;
+  height: 60%;
+}
+
+.roadmap-delivery__step:not(.is-complete) .roadmap-delivery__step-icon svg {
+  width: 68%;
+  height: 68%;
+}
+
+.roadmap-delivery__step-label {
+  display: block;
+  font-weight: 600;
+  font-size: clamp(0.82rem, 2.2vw, 0.95rem);
+  color: var(--text-muted);
+}
+
+.roadmap-delivery__step.is-complete .roadmap-delivery__step-icon {
+  background: var(--accent-green-deep);
+  border-color: var(--accent-green-deep);
+  color: #fff;
+  box-shadow: 0 16px 28px rgba(59, 141, 114, 0.28);
+}
+
+.roadmap-delivery__step.is-complete .roadmap-delivery__step-label {
+  color: var(--text-main);
+}
+
+.roadmap-delivery__step.is-current .roadmap-delivery__step-icon {
+  background: var(--accent-green);
+  border-color: var(--accent-green);
+  transform: scale(1.05);
+}
+
+.roadmap-delivery__step.is-current .roadmap-delivery__step-label {
+  color: var(--accent-green-deep);
+}
+
+.roadmap-delivery__current-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.85rem;
+  border-radius: 999px;
+  background: var(--accent-green-deep);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  box-shadow: 0 12px 26px rgba(59, 141, 114, 0.26);
+}
+
+.roadmap-delivery__store {
+  display: grid;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.roadmap-delivery__store-label {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  color: var(--accent-green-deep);
+}
+
+.roadmap-delivery__store-card {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 1.3rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(98, 187, 161, 0.28);
+  box-shadow: 0 18px 36px rgba(98, 187, 161, 0.2);
+}
+
+.roadmap-delivery__store-icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(98, 187, 161, 0.2), rgba(59, 141, 114, 0.2));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-green-deep);
+}
+
+.roadmap-delivery__store-icon svg {
+  width: 68%;
+  height: 68%;
+}
+
+.roadmap-delivery__store-name {
+  font-size: clamp(1rem, 2.6vw, 1.15rem);
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+@media (max-width: 720px) {
+  .roadmap-delivery__steps {
+    --icon-size: 40px;
+    --steps-padding: clamp(0.6rem, 6vw, 1.8rem);
+    gap: clamp(0.4rem, 4vw, 0.8rem);
+  }
+
+  .roadmap-delivery__step {
+    min-width: max(95px, 18%);
+  }
+
+  .roadmap-delivery__current-badge {
+    font-size: 0.7rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .roadmap-delivery {
+    padding: clamp(1.3rem, 6vw, 1.8rem);
+  }
+
+  .roadmap-delivery__steps {
+    --icon-size: 36px;
+  }
+
+  .roadmap-delivery__step-label {
+    font-size: 0.8rem;
+  }
+
+  .roadmap-delivery__store-card {
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+
+  .roadmap-delivery__store-name {
+    font-size: 1rem;
+  }
+}
+
 .roadmap-current-status {
   display: inline-flex;
   align-items: center;

--- a/roadmap.css
+++ b/roadmap.css
@@ -59,9 +59,9 @@
 }
 
 .roadmap-progress__inner {
-  width: min(1180px, 96vw);
+  width: min(1100px, 100%);
   margin: 0 auto;
-  padding: clamp(1.6rem, 4vw, 2.4rem) clamp(1.4rem, 3.6vw, 2.4rem) clamp(1.8rem, 4.6vw, 2.6rem);
+  padding: clamp(1.4rem, 4vw, 2.2rem) clamp(1rem, 3vw, 1.8rem) clamp(1.6rem, 4.4vw, 2.4rem);
   border-radius: 28px;
   border: 1px solid var(--card-border);
   background: linear-gradient(135deg, rgba(224, 244, 236, 0.96), rgba(255, 255, 255, 0.94));
@@ -82,17 +82,18 @@
 }
 
 .roadmap-progress__steps {
-  --pad-x: clamp(0.8rem, 2.6vw, 1.6rem);
-  --pad-top: clamp(1.1rem, 3vw, 1.6rem);
-  --node-size: 46px;
+  --pad-x: clamp(0.6rem, 2.2vw, 1.2rem);
+  --pad-top: clamp(0.9rem, 2.6vw, 1.4rem);
+  --node-size: clamp(38px, 6vw, 46px);
   --progress-position: 0%;
   list-style: none;
   margin: 0;
   padding: var(--pad-top) var(--pad-x) clamp(1.1rem, 3vw, 1.6rem);
   display: flex;
+  flex-wrap: nowrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: clamp(0.45rem, 2vw, 0.9rem);
+  gap: clamp(0.35rem, 1.8vw, 0.75rem);
   position: relative;
 }
 
@@ -156,14 +157,15 @@
 
 .roadmap-progress__index {
   font-family: var(--heading-font);
-  font-size: clamp(0.75rem, 1.8vw, 0.85rem);
+  font-size: clamp(0.7rem, 1.6vw, 0.85rem);
   letter-spacing: 0.24em;
   color: var(--text-muted);
 }
 
 .roadmap-progress__name {
   font-weight: 600;
-  font-size: clamp(0.9rem, 2.2vw, 1.05rem);
+  font-size: clamp(0.82rem, 2vw, 1.02rem);
+  line-height: 1.35;
   color: var(--text-main);
 }
 
@@ -225,53 +227,56 @@
   color: var(--accent-green-deep);
 }
 
-@media (max-width: 960px) {
-  .roadmap-progress__steps {
-    --node-size: 42px;
+@media (max-width: 1024px) {
+  .roadmap-progress__inner {
+    padding: clamp(1.2rem, 4.8vw, 1.8rem) clamp(0.9rem, 3.2vw, 1.4rem) clamp(1.4rem, 4.8vw, 2rem);
   }
 
-  .roadmap-progress__step {
-    gap: 0.5rem;
+  .roadmap-progress__steps {
+    --pad-x: clamp(0.5rem, 2.4vw, 1rem);
+    --pad-top: clamp(0.75rem, 2.8vw, 1.1rem);
+    gap: clamp(0.3rem, 1.6vw, 0.6rem);
+  }
+
+  .roadmap-progress__index {
+    letter-spacing: 0.2em;
   }
 }
 
 @media (max-width: 720px) {
   .roadmap-progress__inner {
-    width: min(620px, 94vw);
+    border-radius: 24px;
   }
 
   .roadmap-progress__steps {
-    flex-wrap: wrap;
-    justify-content: center;
-    row-gap: clamp(0.8rem, 3vw, 1.2rem);
+    --node-size: clamp(32px, 8vw, 38px);
+    --pad-x: clamp(0.4rem, 3vw, 0.8rem);
+    padding: clamp(0.8rem, 4vw, 1.1rem) var(--pad-x) clamp(0.9rem, 4vw, 1.3rem);
   }
 
-  .roadmap-progress__steps::before {
-    display: none;
+  .roadmap-progress__index {
+    font-size: clamp(0.66rem, 1.8vw, 0.78rem);
+    letter-spacing: 0.18em;
   }
 
-  .roadmap-progress__step {
-    flex: 1 1 calc(50% - 1.2rem);
-    max-width: 240px;
+  .roadmap-progress__name {
+    font-size: clamp(0.74rem, 2.5vw, 0.9rem);
+  }
+
+  .roadmap-progress__badge {
+    padding: 0.18rem 0.65rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
   }
 }
 
 @media (max-width: 520px) {
-  .roadmap-progress__inner {
-    padding: clamp(1.2rem, 6vw, 1.6rem);
-  }
-
   .roadmap-progress__steps {
-    padding: clamp(0.9rem, 4vw, 1.3rem) clamp(0.6rem, 4vw, 1.1rem);
+    gap: clamp(0.25rem, 3vw, 0.45rem);
   }
 
-  .roadmap-progress__step {
-    flex-basis: 100%;
-    max-width: none;
-  }
-
-  .roadmap-progress__badge {
-    font-size: 0.7rem;
+  .roadmap-progress__name {
+    font-size: clamp(0.7rem, 3vw, 0.8rem);
   }
 }
 

--- a/roadmap.css
+++ b/roadmap.css
@@ -54,140 +54,121 @@
   margin: 0;
 }
 
-.roadmap-delivery {
-  margin-top: clamp(1.4rem, 4vw, 2.1rem);
-  padding: clamp(1.6rem, 4.5vw, 2.4rem);
-  border-radius: 26px;
-  border: 1px solid rgba(98, 187, 161, 0.28);
-  background: linear-gradient(140deg, rgba(224, 244, 236, 0.95), rgba(255, 255, 255, 0.92));
-  box-shadow: 0 20px 40px rgba(98, 187, 161, 0.16);
+.roadmap-progress {
+  margin: clamp(2rem, 5vw, 3.2rem) 0 clamp(2.4rem, 6vw, 3.6rem);
+}
+
+.roadmap-progress__inner {
+  width: min(1180px, 96vw);
+  margin: 0 auto;
+  padding: clamp(1.6rem, 4vw, 2.4rem) clamp(1.4rem, 3.6vw, 2.4rem) clamp(1.8rem, 4.6vw, 2.6rem);
+  border-radius: 28px;
+  border: 1px solid var(--card-border);
+  background: linear-gradient(135deg, rgba(224, 244, 236, 0.96), rgba(255, 255, 255, 0.94));
+  box-shadow: 0 24px 48px rgba(98, 187, 161, 0.18);
   display: grid;
-  gap: clamp(1rem, 3.4vw, 1.6rem);
+  gap: clamp(1.2rem, 3vw, 1.8rem);
 }
 
-.roadmap-delivery__header h3 {
-  margin: 0 0 0.3rem;
-  font-size: clamp(1.2rem, 3vw, 1.55rem);
-}
-
-.roadmap-delivery__header p {
+.roadmap-progress__header h2 {
   margin: 0;
-  color: var(--text-muted);
-  font-size: clamp(0.9rem, 2.4vw, 1rem);
+  font-size: clamp(1.4rem, 3.4vw, 1.9rem);
 }
 
-.roadmap-delivery__steps {
-  --icon-size: 44px;
-  --steps-padding: clamp(0.4rem, 3.5vw, 1.6rem);
+.roadmap-progress__header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: clamp(0.96rem, 2.4vw, 1.05rem);
+}
+
+.roadmap-progress__steps {
+  --pad-x: clamp(0.8rem, 2.6vw, 1.6rem);
+  --pad-top: clamp(1.1rem, 3vw, 1.6rem);
+  --node-size: 46px;
+  --progress-position: 0%;
   list-style: none;
   margin: 0;
-  padding: 0 var(--steps-padding) clamp(1rem, 3vw, 1.5rem);
+  padding: var(--pad-top) var(--pad-x) clamp(1.1rem, 3vw, 1.6rem);
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: clamp(0.45rem, 2.4vw, 1rem);
+  gap: clamp(0.45rem, 2vw, 0.9rem);
   position: relative;
-  overflow-x: auto;
 }
 
-.roadmap-delivery__steps::before {
+.roadmap-progress__steps::before {
   content: '';
   position: absolute;
-  top: calc(var(--icon-size) / 2);
-  left: calc(var(--steps-padding) + var(--icon-size) / 2);
-  right: calc(var(--steps-padding) + var(--icon-size) / 2);
+  top: calc(var(--pad-top) + var(--node-size) / 2);
+  left: var(--pad-x);
+  right: var(--pad-x);
   height: 4px;
   border-radius: 999px;
   background: linear-gradient(
     90deg,
-    rgba(98, 187, 161, 0.7) 0%,
-    rgba(98, 187, 161, 0.7) 50%,
-    rgba(166, 205, 189, 0.55) 50%,
-    rgba(166, 205, 189, 0.55) 100%
+    rgba(98, 187, 161, 0.85) 0%,
+    rgba(98, 187, 161, 0.85) var(--progress-position, 0%),
+    rgba(166, 205, 189, 0.5) var(--progress-position, 0%),
+    rgba(166, 205, 189, 0.5) 100%
   );
   pointer-events: none;
+  transition: background 0.3s ease;
 }
 
-.roadmap-delivery__steps::-webkit-scrollbar {
-  height: 6px;
-}
-
-.roadmap-delivery__steps::-webkit-scrollbar-thumb {
-  background: rgba(98, 187, 161, 0.35);
-  border-radius: 999px;
-}
-
-.roadmap-delivery__step {
+.roadmap-progress__step {
   flex: 1;
-  min-width: max(110px, 15%);
+  min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.55rem;
+  gap: clamp(0.35rem, 1.4vw, 0.7rem);
   text-align: center;
   position: relative;
   color: var(--accent-green-deep);
 }
 
-.roadmap-delivery__step-icon {
-  width: var(--icon-size);
-  height: var(--icon-size);
+.roadmap-progress__node {
+  width: var(--node-size);
+  height: var(--node-size);
   border-radius: 50%;
+  border: 2px solid rgba(98, 187, 161, 0.32);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 14px 28px rgba(98, 187, 161, 0.18);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.92);
-  border: 2px solid rgba(98, 187, 161, 0.32);
-  color: rgba(98, 187, 161, 0.5);
-  box-shadow: 0 12px 24px rgba(98, 187, 161, 0.12);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease,
-    color 0.2s ease;
+  color: rgba(98, 187, 161, 0.55);
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
   position: relative;
   z-index: 1;
 }
 
-.roadmap-delivery__step-icon svg {
+.roadmap-progress__icon {
   width: 60%;
   height: 60%;
+  display: none;
 }
 
-.roadmap-delivery__step:not(.is-complete) .roadmap-delivery__step-icon svg {
-  width: 68%;
-  height: 68%;
-}
-
-.roadmap-delivery__step-label {
+.roadmap-progress__icon--pending {
   display: block;
-  font-weight: 600;
-  font-size: clamp(0.82rem, 2.2vw, 0.95rem);
+}
+
+.roadmap-progress__index {
+  font-family: var(--heading-font);
+  font-size: clamp(0.75rem, 1.8vw, 0.85rem);
+  letter-spacing: 0.24em;
   color: var(--text-muted);
 }
 
-.roadmap-delivery__step.is-complete .roadmap-delivery__step-icon {
-  background: var(--accent-green-deep);
-  border-color: var(--accent-green-deep);
-  color: #fff;
-  box-shadow: 0 16px 28px rgba(59, 141, 114, 0.28);
-}
-
-.roadmap-delivery__step.is-complete .roadmap-delivery__step-label {
+.roadmap-progress__name {
+  font-weight: 600;
+  font-size: clamp(0.9rem, 2.2vw, 1.05rem);
   color: var(--text-main);
 }
 
-.roadmap-delivery__step.is-current .roadmap-delivery__step-icon {
-  background: var(--accent-green);
-  border-color: var(--accent-green);
-  transform: scale(1.05);
-}
-
-.roadmap-delivery__step.is-current .roadmap-delivery__step-label {
-  color: var(--accent-green-deep);
-}
-
-.roadmap-delivery__current-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.roadmap-progress__badge {
+  margin-top: 0.2rem;
   padding: 0.25rem 0.85rem;
   border-radius: 999px;
   background: var(--accent-green-deep);
@@ -196,90 +177,101 @@
   font-weight: 700;
   letter-spacing: 0.12em;
   box-shadow: 0 12px 26px rgba(59, 141, 114, 0.26);
+  display: none;
 }
 
-.roadmap-delivery__store {
-  display: grid;
-  gap: 0.75rem;
-  align-items: start;
+.roadmap-progress__step.is-complete .roadmap-progress__node {
+  background: var(--accent-green-deep);
+  border-color: var(--accent-green-deep);
+  color: #fff;
+  box-shadow: 0 18px 32px rgba(59, 141, 114, 0.28);
 }
 
-.roadmap-delivery__store-label {
-  font-weight: 700;
-  font-size: 0.95rem;
-  letter-spacing: 0.06em;
+.roadmap-progress__step.is-complete .roadmap-progress__icon--complete {
+  display: block;
+}
+
+.roadmap-progress__step.is-complete .roadmap-progress__icon--pending {
+  display: none;
+}
+
+.roadmap-progress__step.is-complete .roadmap-progress__index {
+  color: rgba(59, 141, 114, 0.7);
+}
+
+.roadmap-progress__step.is-complete .roadmap-progress__name {
   color: var(--accent-green-deep);
 }
 
-.roadmap-delivery__store-card {
-  display: flex;
-  align-items: center;
-  gap: 0.85rem;
-  padding: 0.95rem 1.3rem;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.94);
-  border: 1px solid rgba(98, 187, 161, 0.28);
-  box-shadow: 0 18px 36px rgba(98, 187, 161, 0.2);
+.roadmap-progress__step.is-current .roadmap-progress__node {
+  background: var(--accent-green);
+  border-color: var(--accent-green);
+  color: #fff;
+  transform: scale(1.08);
+  box-shadow: 0 20px 36px rgba(98, 187, 161, 0.32);
 }
 
-.roadmap-delivery__store-icon {
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 16px;
-  background: linear-gradient(135deg, rgba(98, 187, 161, 0.2), rgba(59, 141, 114, 0.2));
+.roadmap-progress__step.is-current .roadmap-progress__badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.roadmap-progress__step.is-current .roadmap-progress__index {
   color: var(--accent-green-deep);
 }
 
-.roadmap-delivery__store-icon svg {
-  width: 68%;
-  height: 68%;
+.roadmap-progress__step.is-current .roadmap-progress__name {
+  color: var(--accent-green-deep);
 }
 
-.roadmap-delivery__store-name {
-  font-size: clamp(1rem, 2.6vw, 1.15rem);
-  font-weight: 700;
-  color: var(--text-main);
+@media (max-width: 960px) {
+  .roadmap-progress__steps {
+    --node-size: 42px;
+  }
+
+  .roadmap-progress__step {
+    gap: 0.5rem;
+  }
 }
 
 @media (max-width: 720px) {
-  .roadmap-delivery__steps {
-    --icon-size: 40px;
-    --steps-padding: clamp(0.6rem, 6vw, 1.8rem);
-    gap: clamp(0.4rem, 4vw, 0.8rem);
+  .roadmap-progress__inner {
+    width: min(620px, 94vw);
   }
 
-  .roadmap-delivery__step {
-    min-width: max(95px, 18%);
+  .roadmap-progress__steps {
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: clamp(0.8rem, 3vw, 1.2rem);
   }
 
-  .roadmap-delivery__current-badge {
-    font-size: 0.7rem;
+  .roadmap-progress__steps::before {
+    display: none;
+  }
+
+  .roadmap-progress__step {
+    flex: 1 1 calc(50% - 1.2rem);
+    max-width: 240px;
   }
 }
 
 @media (max-width: 520px) {
-  .roadmap-delivery {
-    padding: clamp(1.3rem, 6vw, 1.8rem);
+  .roadmap-progress__inner {
+    padding: clamp(1.2rem, 6vw, 1.6rem);
   }
 
-  .roadmap-delivery__steps {
-    --icon-size: 36px;
+  .roadmap-progress__steps {
+    padding: clamp(0.9rem, 4vw, 1.3rem) clamp(0.6rem, 4vw, 1.1rem);
   }
 
-  .roadmap-delivery__step-label {
-    font-size: 0.8rem;
+  .roadmap-progress__step {
+    flex-basis: 100%;
+    max-width: none;
   }
 
-  .roadmap-delivery__store-card {
-    flex-wrap: wrap;
-    gap: 0.6rem;
-  }
-
-  .roadmap-delivery__store-name {
-    font-size: 1rem;
+  .roadmap-progress__badge {
+    font-size: 0.7rem;
   }
 }
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -42,72 +42,115 @@
         <p class="roadmap-current-status"><span class="roadmap-current-status__label">現在地:</span> <span data-current-stage-label aria-live="polite">未設定</span></p>
         <p class="roadmap-storage-warning" data-storage-warning hidden>ブラウザーの設定により保存機能が利用できない場合があります。そのときはメモが端末に保持されない可能性があります。</p>
 
-        <div class="roadmap-delivery" aria-labelledby="roadmap-delivery-heading">
-          <div class="roadmap-delivery__header">
-            <h3 id="roadmap-delivery-heading">お届けまでのロードマップ</h3>
-            <p>現在の進捗を一目で確認し、次のステップを見通せます。</p>
-          </div>
-          <ol class="roadmap-delivery__steps" aria-label="配送ステップ">
-            <li class="roadmap-delivery__step is-complete">
-              <span class="roadmap-delivery__step-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
-                  <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-              <span class="visually-hidden">在庫確認: 完了</span>
-              <span class="roadmap-delivery__step-label">在庫確認</span>
-            </li>
-            <li class="roadmap-delivery__step is-complete">
-              <span class="roadmap-delivery__step-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
-                  <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-              <span class="visually-hidden">配送手配: 完了</span>
-              <span class="roadmap-delivery__step-label">配送手配</span>
-            </li>
-            <li class="roadmap-delivery__step is-current is-complete">
-              <span class="roadmap-delivery__step-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
-                  <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-              <span class="visually-hidden">注文確定: 現在地</span>
-              <span class="roadmap-delivery__step-label">注文確定</span>
-              <span class="roadmap-delivery__current-badge" aria-hidden="true">現在地</span>
-            </li>
-            <li class="roadmap-delivery__step">
-              <span class="roadmap-delivery__step-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
-                  <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2" />
-                </svg>
-              </span>
-              <span class="visually-hidden">お届け開始: これから</span>
-              <span class="roadmap-delivery__step-label">お届け開始</span>
-            </li>
-            <li class="roadmap-delivery__step">
-              <span class="roadmap-delivery__step-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
-                  <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2" />
-                </svg>
-              </span>
-              <span class="visually-hidden">お届け完了: これから</span>
-              <span class="roadmap-delivery__step-label">お届け完了</span>
-            </li>
-          </ol>
-          <div class="roadmap-delivery__store" role="group" aria-labelledby="roadmap-delivery-heading roadmap-delivery-store">
-            <span class="roadmap-delivery__store-label">配送店舗</span>
-            <div class="roadmap-delivery__store-card">
-              <span class="roadmap-delivery__store-icon" aria-hidden="true">
-                <svg viewBox="0 0 48 48" role="presentation" focusable="false">
-                  <path d="M8 18.5V40h32V18.5M6 21l18-13 18 13" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
-                  <path d="M18 40V28h12v12" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </span>
-              <span class="roadmap-delivery__store-name" id="roadmap-delivery-store">鷹宮桜田２丁目店</span>
-            </div>
-          </div>
+      </div>
+    </section>
+
+    <section class="roadmap-progress" aria-labelledby="roadmap-progress-heading">
+      <div class="roadmap-progress__inner">
+        <div class="roadmap-progress__header">
+          <h2 id="roadmap-progress-heading">回復ステップの現在地</h2>
+          <p>ロードマップの7ステージ全体を俯瞰し、保存した現在地がひと目でわかります。</p>
         </div>
+        <ol class="roadmap-progress__steps" aria-label="トラウマ治療ロードマップのステップ">
+          <li class="roadmap-progress__step" data-progress-stage="stage-1">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 01</span>
+            <span class="roadmap-progress__name">生活基盤の安定</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+          <li class="roadmap-progress__step" data-progress-stage="stage-2">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 02</span>
+            <span class="roadmap-progress__name">心理教育</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+          <li class="roadmap-progress__step" data-progress-stage="stage-3">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 03</span>
+            <span class="roadmap-progress__name">トラウマ耐性スキルの獲得</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+          <li class="roadmap-progress__step" data-progress-stage="stage-4">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 04</span>
+            <span class="roadmap-progress__name">身体的アプローチによるトラウマ処理</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+          <li class="roadmap-progress__step" data-progress-stage="stage-5">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 05</span>
+            <span class="roadmap-progress__name">感情整理によるトラウマ処理</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+          <li class="roadmap-progress__step" data-progress-stage="stage-6">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 06</span>
+            <span class="roadmap-progress__name">自己の再構築</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+          <li class="roadmap-progress__step" data-progress-stage="stage-7">
+            <span class="roadmap-progress__node" aria-hidden="true">
+              <svg class="roadmap-progress__icon roadmap-progress__icon--complete" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <svg class="roadmap-progress__icon roadmap-progress__icon--pending" viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2"></circle>
+              </svg>
+            </span>
+            <span class="roadmap-progress__index">STEP 07</span>
+            <span class="roadmap-progress__name">新しい生き方の確立</span>
+            <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
+            <span class="visually-hidden" data-progress-status>未着手</span>
+          </li>
+        </ol>
       </div>
     </section>
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -41,6 +41,73 @@
         <p>各ステージに取り組みたいことをメモしたり、いまどこにいるかを記録できます。ボタンで現在地をマークすると、ブラウザのローカルストレージに保存され、ページを再読み込みしても保持されます。</p>
         <p class="roadmap-current-status"><span class="roadmap-current-status__label">現在地:</span> <span data-current-stage-label aria-live="polite">未設定</span></p>
         <p class="roadmap-storage-warning" data-storage-warning hidden>ブラウザーの設定により保存機能が利用できない場合があります。そのときはメモが端末に保持されない可能性があります。</p>
+
+        <div class="roadmap-delivery" aria-labelledby="roadmap-delivery-heading">
+          <div class="roadmap-delivery__header">
+            <h3 id="roadmap-delivery-heading">お届けまでのロードマップ</h3>
+            <p>現在の進捗を一目で確認し、次のステップを見通せます。</p>
+          </div>
+          <ol class="roadmap-delivery__steps" aria-label="配送ステップ">
+            <li class="roadmap-delivery__step is-complete">
+              <span class="roadmap-delivery__step-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                  <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+              <span class="visually-hidden">在庫確認: 完了</span>
+              <span class="roadmap-delivery__step-label">在庫確認</span>
+            </li>
+            <li class="roadmap-delivery__step is-complete">
+              <span class="roadmap-delivery__step-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                  <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+              <span class="visually-hidden">配送手配: 完了</span>
+              <span class="roadmap-delivery__step-label">配送手配</span>
+            </li>
+            <li class="roadmap-delivery__step is-current is-complete">
+              <span class="roadmap-delivery__step-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                  <path d="m6 12.5 4 3.5 8-8" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+              <span class="visually-hidden">注文確定: 現在地</span>
+              <span class="roadmap-delivery__step-label">注文確定</span>
+              <span class="roadmap-delivery__current-badge" aria-hidden="true">現在地</span>
+            </li>
+            <li class="roadmap-delivery__step">
+              <span class="roadmap-delivery__step-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                  <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2" />
+                </svg>
+              </span>
+              <span class="visually-hidden">お届け開始: これから</span>
+              <span class="roadmap-delivery__step-label">お届け開始</span>
+            </li>
+            <li class="roadmap-delivery__step">
+              <span class="roadmap-delivery__step-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                  <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2.2" />
+                </svg>
+              </span>
+              <span class="visually-hidden">お届け完了: これから</span>
+              <span class="roadmap-delivery__step-label">お届け完了</span>
+            </li>
+          </ol>
+          <div class="roadmap-delivery__store" role="group" aria-labelledby="roadmap-delivery-heading roadmap-delivery-store">
+            <span class="roadmap-delivery__store-label">配送店舗</span>
+            <div class="roadmap-delivery__store-card">
+              <span class="roadmap-delivery__store-icon" aria-hidden="true">
+                <svg viewBox="0 0 48 48" role="presentation" focusable="false">
+                  <path d="M8 18.5V40h32V18.5M6 21l18-13 18 13" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+                  <path d="M18 40V28h12v12" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+              <span class="roadmap-delivery__store-name" id="roadmap-delivery-store">鷹宮桜田２丁目店</span>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -62,7 +62,7 @@
               </svg>
             </span>
             <span class="roadmap-progress__index">STEP 01</span>
-            <span class="roadmap-progress__name">生活基盤の安定</span>
+            <span class="roadmap-progress__name">生活基盤の<br>安定</span>
             <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
             <span class="visually-hidden" data-progress-status>未着手</span>
           </li>
@@ -90,7 +90,7 @@
               </svg>
             </span>
             <span class="roadmap-progress__index">STEP 03</span>
-            <span class="roadmap-progress__name">トラウマ耐性スキルの獲得</span>
+            <span class="roadmap-progress__name">トラウマ耐性<br>スキル</span>
             <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
             <span class="visually-hidden" data-progress-status>未着手</span>
           </li>
@@ -104,7 +104,7 @@
               </svg>
             </span>
             <span class="roadmap-progress__index">STEP 04</span>
-            <span class="roadmap-progress__name">身体的アプローチによるトラウマ処理</span>
+            <span class="roadmap-progress__name">身体アプローチ<br>で処理</span>
             <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
             <span class="visually-hidden" data-progress-status>未着手</span>
           </li>
@@ -118,7 +118,7 @@
               </svg>
             </span>
             <span class="roadmap-progress__index">STEP 05</span>
-            <span class="roadmap-progress__name">感情整理によるトラウマ処理</span>
+            <span class="roadmap-progress__name">感情整理<br>ワーク</span>
             <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
             <span class="visually-hidden" data-progress-status>未着手</span>
           </li>
@@ -132,7 +132,7 @@
               </svg>
             </span>
             <span class="roadmap-progress__index">STEP 06</span>
-            <span class="roadmap-progress__name">自己の再構築</span>
+            <span class="roadmap-progress__name">自己の<br>再構築</span>
             <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
             <span class="visually-hidden" data-progress-status>未着手</span>
           </li>
@@ -146,7 +146,7 @@
               </svg>
             </span>
             <span class="roadmap-progress__index">STEP 07</span>
-            <span class="roadmap-progress__name">新しい生き方の確立</span>
+            <span class="roadmap-progress__name">新しい生き方<br>の確立</span>
             <span class="roadmap-progress__badge" aria-hidden="true">現在地</span>
             <span class="visually-hidden" data-progress-status>未着手</span>
           </li>


### PR DESCRIPTION
## Summary
- add a delivery-progress block under the roadmap usage introduction
- show the five fulfilment steps with current position indicator and store information
- style the new component with roadmap-specific colors, responsive layout, and accessible labelling

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d3babebc908326a33fd784010b5b23