### PR TITLE
Add tool for externalizing self-critical voice

### DIFF
--- a/partials/quick-access.html
+++ b/partials/quick-access.html
@@ -30,5 +30,16 @@
       </span>
       <span class="quick-access__label">トリガー記録</span>
     </a>
+    <a href="voice-tool.html" class="quick-access__link quick-access__link--voice" rel="noopener noreferrer">
+      <span class="quick-access__icon" aria-hidden="true">
+        <svg class="quick-access__icon-svg" viewBox="0 0 24 24" role="presentation" focusable="false">
+          <path d="M12 4.5a3.5 3.5 0 0 0-3.5 3.5v4.2a3.5 3.5 0 1 0 7 0V8a3.5 3.5 0 0 0-3.5-3.5Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+          <path d="M6.8 10.5V11a5.2 5.2 0 0 0 4.7 5.2v2.3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+          <path d="M17.2 10.5V11a5.2 5.2 0 0 1-4.7 5.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+          <path d="M8.5 20.5h7" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+      </span>
+      <span class="quick-access__label">責める声ツール</span>
+    </a>
   </div>
 </nav>

--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,9 @@
   --accent-green: #62bba1;
   --accent-green-deep: #3b8d72;
   --accent-green-soft: #e0f4ec;
+  --accent-purple: #8a6ad6;
   --accent-orange: #ff8a3d;
+  --accent-red: #d0615f;
   --accent-orange-deep: #ff6b1a;
   --text-main: #3a3a3a;
   --text-muted: #6e6e6e;

--- a/voice-tool.css
+++ b/voice-tool.css
@@ -60,6 +60,101 @@ body.voice-tool-page .bandage-icon .bandage-hole {
   gap: 0.65rem;
 }
 
+.saved-characters {
+  margin-top: 1.6rem;
+  padding: 1.2rem 1.3rem;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(153, 129, 212, 0.18);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  display: grid;
+  gap: 1rem;
+}
+
+.saved-characters__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.saved-characters__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.saved-characters__new {
+  padding-inline: 0;
+}
+
+.saved-characters__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.saved-characters__item {
+  display: block;
+}
+
+.saved-characters__button {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(153, 129, 212, 0.28);
+  background: rgba(255, 255, 255, 0.94);
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+
+.saved-characters__button:hover {
+  border-color: rgba(153, 129, 212, 0.5);
+  box-shadow: 0 10px 16px rgba(153, 129, 212, 0.18);
+}
+
+.saved-characters__button:focus-visible {
+  outline: 3px solid rgba(153, 129, 212, 0.3);
+  outline-offset: 2px;
+}
+
+.saved-characters__button.is-active {
+  border-color: var(--accent);
+  background: rgba(243, 237, 255, 0.92);
+  box-shadow: 0 12px 24px rgba(153, 129, 212, 0.25);
+}
+
+.saved-characters__name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.saved-characters__meta {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.saved-characters__empty {
+  margin: 0;
+  padding: 0.8rem;
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(153, 129, 212, 0.35);
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
 .character-form {
   display: grid;
   gap: 1.8rem;

--- a/voice-tool.css
+++ b/voice-tool.css
@@ -1,0 +1,400 @@
+body.voice-tool-page {
+  --bg-gradient: linear-gradient(135deg, #f9f4ff 0%, #f4f8ff 100%);
+  --card-bg: rgba(255, 255, 255, 0.94);
+  --card-border: rgba(203, 201, 232, 0.7);
+  --accent: var(--accent-purple);
+  --accent-soft: #d9cff1;
+  --shadow-soft: 0 22px 42px rgba(153, 129, 212, 0.18);
+  --shadow-card: 0 20px 36px rgba(153, 129, 212, 0.14);
+}
+
+body.voice-tool-page {
+  background: var(--bg-gradient);
+}
+
+body.voice-tool-page .quick-access {
+  --accent: var(--accent-purple);
+  --accent-soft: #d9cff1;
+}
+
+body.voice-tool-page .site-header.voice-tool-header {
+  background: radial-gradient(circle at 20% 25%, rgba(255, 255, 255, 0.65), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.4), transparent 60%),
+    linear-gradient(140deg, rgba(187, 174, 235, 0.7), rgba(214, 223, 248, 0.65));
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.6);
+}
+
+body.voice-tool-page .bandage-icon .bandage-base {
+  fill: var(--accent);
+}
+
+body.voice-tool-page .bandage-icon .bandage-center {
+  fill: #efeaff;
+}
+
+body.voice-tool-page .bandage-icon .bandage-hole {
+  fill: var(--accent);
+}
+
+.voice-tool-main {
+  padding-bottom: 4rem;
+}
+
+.voice-tool-section + .voice-tool-section {
+  margin-top: 2.8rem;
+}
+
+.voice-card {
+  position: relative;
+  z-index: 1;
+  padding: 2.4rem clamp(1.4rem, 3vw, 2.6rem);
+  background: var(--card-bg);
+  border-radius: var(--radius-xxl);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(16px);
+}
+
+.voice-card__header {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.character-form {
+  display: grid;
+  gap: 1.8rem;
+  margin-top: 1.8rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.4rem;
+}
+
+@media (min-width: 720px) {
+  .form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.form-field {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.field-error {
+  margin: 0;
+  color: var(--accent-red);
+  font-size: 0.9rem;
+}
+
+.field-required,
+.field-optional {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-left: 0.4rem;
+}
+
+.field-required {
+  color: var(--accent);
+}
+
+.field-optional {
+  color: var(--text-muted);
+}
+
+.appearance-inputs {
+  display: grid;
+  gap: 0.9rem;
+}
+
+@media (min-width: 720px) {
+  .appearance-inputs {
+    grid-template-columns: minmax(0, 220px) 1fr;
+    align-items: start;
+  }
+}
+
+.input-with-counter {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.input-with-counter input {
+  flex: 1;
+}
+
+.char-count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.character-form input,
+.character-form textarea,
+.character-form select {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(153, 129, 212, 0.45);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 1px 0 rgba(153, 129, 212, 0.08);
+  font: inherit;
+  color: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.character-form input:focus-visible,
+.character-form textarea:focus-visible,
+.character-form select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(153, 129, 212, 0.25);
+}
+
+.character-form textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.voice-submit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.85rem 1.9rem;
+  border-radius: var(--radius-full);
+  border: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.05rem;
+  cursor: pointer;
+  box-shadow: 0 16px 28px rgba(153, 129, 212, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.voice-submit-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 34px rgba(153, 129, 212, 0.3);
+}
+
+.voice-submit-button:focus-visible {
+  outline: 3px solid rgba(153, 129, 212, 0.35);
+  outline-offset: 3px;
+}
+
+.form-feedback {
+  margin-top: 1.2rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.form-feedback.is-error {
+  color: var(--accent-red);
+}
+
+.voice-card--placement {
+  display: grid;
+  gap: 1.8rem;
+}
+
+.placement-room {
+  display: grid;
+  gap: 1.4rem;
+  padding: 1.6rem;
+  border-radius: var(--radius-xl);
+  border: 1px dashed rgba(153, 129, 212, 0.4);
+  background: rgba(247, 244, 255, 0.7);
+}
+
+.room-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+@media (min-width: 720px) {
+  .room-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.placement-spot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(153, 129, 212, 0.45);
+  background: rgba(255, 255, 255, 0.95);
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.placement-spot:hover {
+  background: rgba(153, 129, 212, 0.12);
+  border-color: rgba(153, 129, 212, 0.6);
+}
+
+.placement-spot:focus-visible {
+  outline: 3px solid rgba(153, 129, 212, 0.35);
+  outline-offset: 3px;
+}
+
+.placement-spot.is-active {
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 14px 26px rgba(153, 129, 212, 0.32);
+}
+
+.placement-display {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(153, 129, 212, 0.25);
+  padding: 1.4rem;
+  min-height: 180px;
+  display: grid;
+  align-items: start;
+}
+
+.placement-empty {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.placement-character {
+  display: grid;
+  gap: 1rem;
+}
+
+.placement-name {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.placement-details {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.placement-details div {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.placement-details dt {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.placement-details dd {
+  margin: 0;
+}
+
+.placement-phrases,
+.placement-reminder {
+  margin: 0;
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+.placement-reminder {
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-lg);
+  background: rgba(153, 129, 212, 0.08);
+  border: 1px solid rgba(153, 129, 212, 0.18);
+}
+
+.placement-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: flex-end;
+}
+
+.text-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(153, 129, 212, 0.35);
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.text-button:hover {
+  background: rgba(153, 129, 212, 0.12);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(153, 129, 212, 0.18);
+}
+
+.text-button:focus-visible {
+  outline: 3px solid rgba(153, 129, 212, 0.35);
+  outline-offset: 3px;
+}
+
+.text-button--danger {
+  color: var(--accent-red);
+  border-color: rgba(208, 97, 95, 0.45);
+}
+
+.text-button--danger:hover {
+  background: rgba(208, 97, 95, 0.12);
+  box-shadow: 0 12px 24px rgba(208, 97, 95, 0.18);
+}
+
+.voice-card--support {
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.support-link {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.support-link:hover {
+  text-decoration: none;
+}
+
+@media (max-width: 599px) {
+  .voice-card {
+    padding: 1.8rem 1.25rem;
+  }
+
+  .voice-card--placement {
+    gap: 1.4rem;
+  }
+
+  .placement-display {
+    padding: 1.1rem;
+  }
+}

--- a/voice-tool.css
+++ b/voice-tool.css
@@ -144,6 +144,35 @@ body.voice-tool-page .bandage-icon .bandage-hole {
   color: var(--text-muted);
 }
 
+.saved-characters__details {
+  display: grid;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+.saved-characters__detail {
+  margin: 0;
+  display: grid;
+  gap: 0.2rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.saved-characters__detail-label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.saved-characters__detail-value {
+  color: var(--text-main);
+  white-space: pre-line;
+}
+
+.saved-characters__detail-value.is-empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .saved-characters__empty {
   margin: 0;
   padding: 0.8rem;
@@ -376,15 +405,59 @@ body.voice-tool-page .bandage-icon .bandage-hole {
   line-height: 1.7;
 }
 
-.placement-character {
+.placement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
   gap: 1rem;
 }
 
+.placement-list__item {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(153, 129, 212, 0.28);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.placement-list__item.is-active {
+  border-color: var(--accent);
+  box-shadow: 0 12px 24px rgba(153, 129, 212, 0.25);
+}
+
+.placement-character {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.placement-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
 .placement-name {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: 1.2rem;
   font-weight: 700;
+}
+
+.placement-location {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: var(--radius-full);
+  background: rgba(153, 129, 212, 0.12);
+  color: var(--accent-purple);
+  font-weight: 600;
+  font-size: 0.85rem;
 }
 
 .placement-details {
@@ -419,6 +492,12 @@ body.voice-tool-page .bandage-icon .bandage-hole {
   border-radius: var(--radius-lg);
   background: rgba(153, 129, 212, 0.08);
   border: 1px solid rgba(153, 129, 212, 0.18);
+}
+
+.placement-phrases.is-empty,
+.placement-reminder.is-empty {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .placement-actions {

--- a/voice-tool.html
+++ b/voice-tool.html
@@ -146,16 +146,7 @@
             </div>
             <div class="placement-display" id="placement-display">
               <p class="placement-empty" data-empty-message>まだ部屋に置いていません。下の「ここに置いておく」を押すと、好きな位置に置けます。</p>
-              <div class="placement-character" data-character-display hidden>
-                <h3 class="placement-name" id="placement-name"></h3>
-                <dl class="placement-details">
-                  <div><dt>性別</dt><dd id="placement-gender">-</dd></div>
-                  <div><dt>年齢</dt><dd id="placement-age">-</dd></div>
-                  <div><dt>姿</dt><dd id="placement-appearance">-</dd></div>
-                </dl>
-                <p class="placement-phrases" id="placement-phrases"></p>
-                <p class="placement-reminder" id="placement-reminder"></p>
-              </div>
+              <ul class="placement-list" id="placement-list" aria-label="配置したキャラクター一覧" hidden></ul>
             </div>
           </div>
           <div class="placement-actions">

--- a/voice-tool.html
+++ b/voice-tool.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="複雑性PTSDの方が責める声を安全に外在化し、安心できる場所に置いておくためのキャラクター化ツールです。記録は端末内に保存されます。">
+  <title>責める声のキャラ化ツール</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="voice-tool.css">
+</head>
+<body class="voice-tool-page">
+  <div data-include="partials/quick-access.html"></div>
+  <header id="top" class="site-header voice-tool-header">
+    <div class="inner">
+      <p class="eyebrow" aria-label="Voice Externalization Tool">
+        <span class="eyebrow-icon" aria-hidden="true">
+          <svg class="bandage-icon" viewBox="0 0 64 24" role="presentation" focusable="false">
+            <rect class="bandage-base" x="4" y="6" width="56" height="12" rx="6"></rect>
+            <rect class="bandage-center" x="22" y="4" width="20" height="16" rx="5"></rect>
+            <circle class="bandage-hole" cx="28" cy="12" r="1.4"></circle>
+            <circle class="bandage-hole" cx="32" cy="12" r="1.4"></circle>
+            <circle class="bandage-hole" cx="36" cy="12" r="1.4"></circle>
+          </svg>
+        </span>
+        <span class="eyebrow-label">Voice Externalization Tool</span>
+      </p>
+      <h1 class="hero-title" aria-label="責める声のキャラ化ツール">
+        <span>責める声を</span>
+        <span>そっと部屋に置く</span>
+      </h1>
+      <p class="hero-lead">自分を責める声を安全にキャラクター化し、距離を置く練習ページです。</p>
+      <div class="hero-actions">
+        <a class="hero-link hero-link--log" href="#voice-tool-form">
+          <span class="hero-link__label">キャラを作る</span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class="voice-tool-main">
+    <section class="voice-tool-section">
+      <div class="inner">
+        <div class="voice-card surface-card voice-card--form">
+          <div class="voice-card__header usage-guide">
+            <h2 id="voice-tool-form" class="section-title">責める声のキャラ化フォーム</h2>
+            <p class="section-description">イメージを外に出すことで、心の中の距離を作る手助けになります。入力は端末にのみ保存されます。</p>
+          </div>
+          <form id="character-form" class="character-form" novalidate autocomplete="off">
+            <div class="form-grid">
+              <div class="form-field" data-field="name">
+                <label for="character-name">名前 <span class="field-required">必須</span></label>
+                <div class="input-with-counter">
+                  <input type="text" id="character-name" name="name" inputmode="text" maxlength="40" data-maxlength="40" required>
+                  <span class="char-count" data-count-for="character-name">0 / 40</span>
+                </div>
+                <p class="field-hint">呼びかけやすい呼び名をつけましょう。</p>
+                <p class="field-error" data-error-target="name" aria-live="polite"></p>
+              </div>
+
+              <div class="form-field">
+                <label for="character-gender">性別 <span class="field-optional">任意</span></label>
+                <select id="character-gender" name="gender">
+                  <option value="">選択しない</option>
+                  <option value="女性">女性</option>
+                  <option value="男性">男性</option>
+                  <option value="中性">中性</option>
+                  <option value="不明">不明</option>
+                </select>
+              </div>
+
+              <div class="form-field" data-field="age">
+                <label for="character-age">年齢 <span class="field-optional">任意</span></label>
+                <input type="number" id="character-age" name="age" inputmode="numeric" min="0" max="120" step="1">
+                <p class="field-hint">数字がしっくり来ない場合は空白のままでOKです。</p>
+                <p class="field-error" data-error-target="age" aria-live="polite"></p>
+              </div>
+            </div>
+
+            <div class="form-field">
+              <label for="character-appearance">姿のイメージ <span class="field-optional">任意</span></label>
+              <div class="appearance-inputs">
+                <select id="character-appearance" name="appearancePreset">
+                  <option value="">選択しない</option>
+                  <option value="影">影</option>
+                  <option value="霧">霧</option>
+                  <option value="動物">動物</option>
+                  <option value="人物">人物</option>
+                  <option value="物体">物体</option>
+                  <option value="その他">その他</option>
+                </select>
+                <div class="input-with-counter">
+                  <input type="text" id="character-appearance-detail" name="appearanceDetail" inputmode="text" maxlength="80" data-maxlength="80" placeholder="短くメモ（最大80文字）">
+                  <span class="char-count" data-count-for="character-appearance-detail">0 / 80</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-field">
+              <label for="character-phrases">よく言う言葉 <span class="field-optional">任意</span></label>
+              <textarea id="character-phrases" name="phrases" rows="4" maxlength="300" data-maxlength="300" placeholder="頭の中で繰り返される言葉を書き留めておきましょう"></textarea>
+              <div class="field-footer">
+                <span class="char-count" data-count-for="character-phrases">0 / 300</span>
+              </div>
+            </div>
+
+            <div class="form-field">
+              <label for="character-reminder">伝えたい言葉 <span class="field-optional">任意</span></label>
+              <textarea id="character-reminder" name="reminder" rows="4" maxlength="300" data-maxlength="300" placeholder="落ち着いたときの自分から伝えたいメッセージ"></textarea>
+              <div class="field-footer">
+                <span class="char-count" data-count-for="character-reminder">0 / 300</span>
+              </div>
+            </div>
+
+            <div class="form-actions">
+              <button type="submit" class="voice-submit-button">保存する</button>
+            </div>
+            <p class="form-feedback" id="form-feedback" aria-live="polite"></p>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="voice-tool-section">
+      <div class="inner">
+        <div class="voice-card surface-card voice-card--placement">
+          <div class="voice-card__header">
+            <h2 class="section-title">置き場所</h2>
+            <p class="section-description">広い部屋の中の安全な場所に置いて、今の自分との距離を確かめましょう。</p>
+          </div>
+          <div class="placement-room" role="region" aria-live="polite" aria-label="キャラクターの置き場所">
+            <div class="room-grid" id="placement-grid">
+              <button type="button" class="placement-spot" data-spot="window" aria-pressed="false">窓辺</button>
+              <button type="button" class="placement-spot" data-spot="sofa" aria-pressed="false">ソファのそば</button>
+              <button type="button" class="placement-spot" data-spot="shelf" aria-pressed="false">棚の上</button>
+              <button type="button" class="placement-spot" data-spot="door" aria-pressed="false">ドアのそば</button>
+            </div>
+            <div class="placement-display" id="placement-display">
+              <p class="placement-empty" data-empty-message>まだ部屋に置いていません。下の「ここに置いておく」を押すと、好きな位置に置けます。</p>
+              <div class="placement-character" data-character-display hidden>
+                <h3 class="placement-name" id="placement-name"></h3>
+                <dl class="placement-details">
+                  <div><dt>性別</dt><dd id="placement-gender">-</dd></div>
+                  <div><dt>年齢</dt><dd id="placement-age">-</dd></div>
+                  <div><dt>姿</dt><dd id="placement-appearance">-</dd></div>
+                </dl>
+                <p class="placement-phrases" id="placement-phrases"></p>
+                <p class="placement-reminder" id="placement-reminder"></p>
+              </div>
+            </div>
+          </div>
+          <div class="placement-actions">
+            <button type="button" class="text-button" id="place-character-button">ここに置いておく</button>
+            <button type="button" class="text-button text-button--danger" id="clear-placement-button">位置をクリア</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="voice-tool-section">
+      <div class="inner">
+        <div class="voice-card surface-card voice-card--support">
+          <h2 class="section-title">つらくなったら</h2>
+          <p class="section-description">
+            感情が強くなりすぎたときは、作業を中断して落ち着くためのステップを試しましょう。
+            <a href="index.html#favorites-five-senses" class="support-link">フラッシュバック応急処置ガイドはこちら</a>
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <div data-include="partials/note.html"></div>
+  </main>
+
+  <div data-include="partials/site-footer.html"></div>
+
+  <noscript>
+    <p class="noscript-message">JavaScriptを有効にするとキャラクターの保存や置き場所の表示が利用できます。</p>
+  </noscript>
+
+  <div data-include="partials/back-to-top.html"></div>
+
+  <script src="component-loader.js" defer></script>
+  <script src="voice-tool.js" defer></script>
+</body>
+</html>

--- a/voice-tool.html
+++ b/voice-tool.html
@@ -48,6 +48,13 @@
             <h2 id="voice-tool-form" class="section-title">責める声のキャラ化フォーム</h2>
             <p class="section-description">イメージを外に出すことで、心の中の距離を作る手助けになります。入力は端末にのみ保存されます。</p>
           </div>
+          <div class="saved-characters" aria-live="polite">
+            <div class="saved-characters__header">
+              <h3 class="saved-characters__title">保存したキャラクター</h3>
+              <button type="button" class="text-button saved-characters__new" id="create-character-button">新しく作る</button>
+            </div>
+            <ul class="saved-characters__list" id="saved-characters-list"></ul>
+          </div>
           <form id="character-form" class="character-form" novalidate autocomplete="off">
             <div class="form-grid">
               <div class="form-field" data-field="name">

--- a/voice-tool.js
+++ b/voice-tool.js
@@ -1,0 +1,461 @@
+(() => {
+  'use strict';
+
+  const STORAGE_KEY_PROFILE = 'voiceCharacterProfile';
+  const STORAGE_KEY_PLACEMENT = 'voiceCharacterPlacement';
+
+  const state = {
+    form: null,
+    feedback: null,
+    selectedSpot: null,
+    profile: createEmptyProfile(),
+    placement: null,
+  };
+
+  whenDocumentReady(init);
+
+  function whenDocumentReady(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function init() {
+    const form = document.getElementById('character-form');
+    if (!form) {
+      return;
+    }
+
+    state.form = form;
+    state.feedback = document.getElementById('form-feedback');
+
+    initializeCharCounters(form);
+
+    form.addEventListener('submit', handleFormSubmit);
+
+    const grid = document.getElementById('placement-grid');
+    if (grid) {
+      grid.addEventListener('click', handleSpotClick);
+    }
+
+    const placeButton = document.getElementById('place-character-button');
+    if (placeButton) {
+      placeButton.addEventListener('click', handlePlaceCharacter);
+    }
+
+    const clearPlacementButton = document.getElementById('clear-placement-button');
+    if (clearPlacementButton) {
+      clearPlacementButton.addEventListener('click', handleClearPlacement);
+    }
+
+    const savedProfile = loadProfile();
+    if (savedProfile) {
+      state.profile = savedProfile;
+      populateForm(savedProfile);
+    }
+
+    const savedPlacement = loadPlacement();
+    if (savedPlacement) {
+      state.placement = savedPlacement;
+      state.selectedSpot = savedPlacement.spot || null;
+    }
+
+    renderPlacement();
+  }
+
+  function createEmptyProfile() {
+    return {
+      name: '',
+      gender: '',
+      age: '',
+      appearancePreset: '',
+      appearanceDetail: '',
+      phrases: '',
+      reminder: '',
+    };
+  }
+
+  function handleFormSubmit(event) {
+    event.preventDefault();
+
+    const form = state.form;
+    if (!form) {
+      return;
+    }
+
+    const formData = new FormData(form);
+
+    const nameRaw = getFormValue(formData, 'name');
+    const genderRaw = getFormValue(formData, 'gender');
+    const ageRaw = getFormValue(formData, 'age');
+    const appearancePresetRaw = getFormValue(formData, 'appearancePreset');
+    const appearanceDetailRaw = getFormValue(formData, 'appearanceDetail');
+    const phrasesRaw = getFormValue(formData, 'phrases');
+    const reminderRaw = getFormValue(formData, 'reminder');
+
+    clearFieldError('name');
+    clearFieldError('age');
+
+    const name = sanitizeString(nameRaw, 40);
+    if (!name) {
+      setFieldError('name', '1〜40文字で入力してください。');
+      showFeedback('保存できませんでした。必須項目を確認してください。', true);
+      return;
+    }
+
+    const gender = sanitizeGender(genderRaw);
+
+    const age = sanitizeAge(ageRaw);
+    if (age === null) {
+      setFieldError('age', '0〜120の数字を入力してください。');
+      showFeedback('保存できませんでした。入力内容を確認してください。', true);
+      return;
+    }
+
+    const appearancePreset = sanitizeAppearancePreset(appearancePresetRaw);
+    const appearanceDetail = sanitizeString(appearanceDetailRaw, 80);
+    const phrases = sanitizeMultiline(phrasesRaw, 300);
+    const reminder = sanitizeMultiline(reminderRaw, 300);
+
+    const profile = {
+      name,
+      gender,
+      age: age === '' ? '' : String(age),
+      appearancePreset,
+      appearanceDetail,
+      phrases,
+      reminder,
+    };
+
+    if (!persistProfile(profile)) {
+      showFeedback('保存中にエラーが発生しました。ブラウザの設定をご確認ください。', true);
+      return;
+    }
+
+    state.profile = profile;
+    showFeedback('キャラクターを保存しました。置き場所を決めることもできます。');
+    renderPlacement();
+  }
+
+  function getFormValue(formData, key) {
+    const value = formData.get(key);
+    return typeof value === 'string' ? value : '';
+  }
+
+  function sanitizeString(value, maxLength) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    let sanitized = value.normalize('NFC').replace(/[\u0000-\u001F\u007F]/g, '').trim();
+    if (sanitized.length > maxLength) {
+      sanitized = sanitized.slice(0, maxLength);
+    }
+    return sanitized;
+  }
+
+  function sanitizeMultiline(value, maxLength) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    let sanitized = value.normalize('NFC').replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+    if (sanitized.length > maxLength) {
+      sanitized = sanitized.slice(0, maxLength);
+    }
+    return sanitized.trim();
+  }
+
+  function sanitizeGender(value) {
+    const allowed = ['', '女性', '男性', '中性', '不明'];
+    return allowed.includes(value) ? value : '';
+  }
+
+  function sanitizeAppearancePreset(value) {
+    const allowed = ['', '影', '霧', '動物', '人物', '物体', 'その他'];
+    return allowed.includes(value) ? value : '';
+  }
+
+  function sanitizeAge(value) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (!trimmed) {
+      return '';
+    }
+    if (!/^\d{1,3}$/.test(trimmed)) {
+      return null;
+    }
+    const ageNumber = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(ageNumber) || ageNumber < 0 || ageNumber > 120) {
+      return null;
+    }
+    return ageNumber;
+  }
+
+  function setFieldError(fieldName, message) {
+    const errorTarget = document.querySelector(`[data-error-target="${fieldName}"]`);
+    if (errorTarget) {
+      errorTarget.textContent = message;
+    }
+  }
+
+  function clearFieldError(fieldName) {
+    setFieldError(fieldName, '');
+  }
+
+  function showFeedback(message, isError = false) {
+    const feedback = state.feedback;
+    if (!feedback) {
+      return;
+    }
+
+    feedback.textContent = message;
+    feedback.classList.toggle('is-error', Boolean(isError));
+  }
+
+  function initializeCharCounters(form) {
+    const fields = form.querySelectorAll('textarea, input[type="text"]');
+    fields.forEach((field) => {
+      if (!field.id) {
+        return;
+      }
+      updateCharCount(field);
+      field.addEventListener('input', () => updateCharCount(field));
+    });
+  }
+
+  function updateCharCount(field) {
+    const target = document.querySelector(`[data-count-for="${field.id}"]`);
+    if (!target) {
+      return;
+    }
+    const maxLength = getFieldMaxLength(field);
+    target.textContent = `${field.value.length} / ${maxLength}`;
+  }
+
+  function getFieldMaxLength(field) {
+    if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement) {
+      if (field.maxLength && field.maxLength > 0) {
+        return field.maxLength;
+      }
+    }
+    const attr = field.getAttribute('data-maxlength');
+    const parsed = attr ? Number.parseInt(attr, 10) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1000;
+  }
+
+  function populateForm(profile) {
+    const form = state.form;
+    if (!form) {
+      return;
+    }
+    setInputValue(form, 'character-name', profile.name);
+    setInputValue(form, 'character-gender', profile.gender);
+    setInputValue(form, 'character-age', profile.age);
+    setInputValue(form, 'character-appearance', profile.appearancePreset);
+    setInputValue(form, 'character-appearance-detail', profile.appearanceDetail);
+    setInputValue(form, 'character-phrases', profile.phrases);
+    setInputValue(form, 'character-reminder', profile.reminder);
+  }
+
+  function setInputValue(form, fieldId, value) {
+    const field = form.querySelector(`#${fieldId}`);
+    if (!field) {
+      return;
+    }
+    if (field instanceof HTMLInputElement || field instanceof HTMLSelectElement) {
+      field.value = typeof value === 'string' ? value : '';
+    } else if (field instanceof HTMLTextAreaElement) {
+      field.value = typeof value === 'string' ? value : '';
+    }
+    updateCharCount(field);
+  }
+
+  function persistProfile(profile) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY_PROFILE, JSON.stringify(profile));
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function loadProfile() {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY_PROFILE);
+      if (!stored) {
+        return null;
+      }
+      const parsed = JSON.parse(stored);
+      if (!parsed || typeof parsed !== 'object') {
+        return null;
+      }
+      return {
+        name: sanitizeString(parsed.name ?? '', 40),
+        gender: sanitizeGender(parsed.gender ?? ''),
+        age: normalizeAgeValue(parsed.age),
+        appearancePreset: sanitizeAppearancePreset(parsed.appearancePreset ?? ''),
+        appearanceDetail: sanitizeString(parsed.appearanceDetail ?? '', 80),
+        phrases: sanitizeMultiline(parsed.phrases ?? '', 300),
+        reminder: sanitizeMultiline(parsed.reminder ?? '', 300),
+      };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function normalizeAgeValue(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      if (value < 0 || value > 120) {
+        return '';
+      }
+      return String(Math.trunc(value));
+    }
+    if (typeof value === 'string') {
+      const sanitized = sanitizeAge(value);
+      if (sanitized === null) {
+        return '';
+      }
+      return sanitized === '' ? '' : String(sanitized);
+    }
+    return '';
+  }
+
+  function handleSpotClick(event) {
+    const button = event.target instanceof HTMLElement ? event.target.closest('.placement-spot') : null;
+    if (!button || !button.dataset.spot) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const spot = button.dataset.spot;
+    state.selectedSpot = spot;
+    updateSpotSelection(spot);
+  }
+
+  function updateSpotSelection(activeSpot) {
+    const buttons = document.querySelectorAll('.placement-spot');
+    buttons.forEach((button) => {
+      const isActive = button.dataset.spot === activeSpot;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  function handlePlaceCharacter() {
+    if (!state.profile || !state.profile.name) {
+      showFeedback('キャラクターを先に保存してください。', true);
+      return;
+    }
+
+    const spot = state.selectedSpot;
+    if (!spot) {
+      showFeedback('置き場所を選んでください。', true);
+      return;
+    }
+
+    const placement = { spot };
+    if (!persistPlacement(placement)) {
+      showFeedback('位置を保存できませんでした。ブラウザの設定をご確認ください。', true);
+      return;
+    }
+
+    state.placement = placement;
+    showFeedback('選んだ場所にそっと置きました。', false);
+    renderPlacement();
+  }
+
+  function handleClearPlacement() {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY_PLACEMENT);
+    } catch (error) {
+      // ignore storage errors on remove
+    }
+    state.placement = null;
+    state.selectedSpot = null;
+    updateSpotSelection(null);
+    renderPlacement();
+    showFeedback('置き場所をリセットしました。');
+  }
+
+  function renderPlacement() {
+    const display = document.querySelector('[data-character-display]');
+    const emptyMessage = document.querySelector('[data-empty-message]');
+    const profile = state.profile;
+    const placement = state.placement;
+
+    if (!display || !emptyMessage) {
+      return;
+    }
+
+    if (placement && placement.spot && profile && profile.name) {
+      emptyMessage.hidden = true;
+      display.hidden = false;
+      updateSpotSelection(placement.spot);
+      state.selectedSpot = placement.spot;
+
+      setTextContent('placement-name', profile.name);
+      setTextContent('placement-gender', profile.gender || '選択なし');
+      setTextContent('placement-age', profile.age ? `${profile.age}歳` : '選択なし');
+      setTextContent('placement-appearance', formatAppearance(profile));
+      setTextContent('placement-phrases', profile.phrases);
+      setTextContent('placement-reminder', profile.reminder);
+    } else {
+      emptyMessage.hidden = false;
+      display.hidden = true;
+      updateSpotSelection(state.selectedSpot || null);
+    }
+  }
+
+  function setTextContent(id, value) {
+    const element = document.getElementById(id);
+    if (!element) {
+      return;
+    }
+    element.textContent = value || '';
+  }
+
+  function formatAppearance(profile) {
+    const parts = [];
+    if (profile.appearancePreset) {
+      parts.push(profile.appearancePreset);
+    }
+    if (profile.appearanceDetail) {
+      parts.push(profile.appearanceDetail);
+    }
+    if (!parts.length) {
+      return '選択なし';
+    }
+    return parts.join(' / ');
+  }
+
+  function persistPlacement(placement) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY_PLACEMENT, JSON.stringify(placement));
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function loadPlacement() {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY_PLACEMENT);
+      if (!stored) {
+        return null;
+      }
+      const parsed = JSON.parse(stored);
+      if (!parsed || typeof parsed !== 'object') {
+        return null;
+      }
+      const spot = typeof parsed.spot === 'string' ? parsed.spot : '';
+      const allowedSpots = ['window', 'sofa', 'shelf', 'door'];
+      if (!allowedSpots.includes(spot)) {
+        return null;
+      }
+      return { spot };
+    } catch (error) {
+      return null;
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- add a dedicated page for characterizing and placing a self-critical voice, including emergency guide link
- implement page-specific styling and client-side logic with sanitized local storage persistence
- surface the new tool in the quick access navigation and add supporting design tokens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88d283bb88326a129468c756e6944