### PR TITLE
Add guided externalization tool experience

### DIFF
--- a/externalization-tool.css
+++ b/externalization-tool.css
@@ -1,0 +1,373 @@
+.externalization-page {
+  background: var(--bg-gradient);
+}
+
+.externalization-header {
+  padding: clamp(3.2rem, 8vw, 4.6rem) 0 clamp(2.4rem, 6vw, 3.2rem);
+  text-align: center;
+}
+
+.externalization-header .hero-title span:first-child {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.externalization-header .hero-title span:last-child {
+  font-size: clamp(1.6rem, 3.2vw, 2.1rem);
+}
+
+.externalization-header__icon {
+  width: clamp(3rem, 6vw, 3.8rem);
+  height: auto;
+}
+
+.externalization-main {
+  padding-bottom: clamp(4rem, 8vw, 5rem);
+}
+
+.externalization-section + .externalization-section {
+  margin-top: clamp(2.8rem, 6vw, 3.5rem);
+}
+
+.externalization-card {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.6rem, 4vw, 2rem);
+}
+
+.externalization-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.externalization-card__header--list {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+.externalization-card__header--list .section-title {
+  margin: 0;
+}
+
+.externalization-card__header--list .text-button {
+  white-space: nowrap;
+}
+
+.wizard-progress {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(0.75rem, 3vw, 1rem);
+  list-style: none;
+}
+
+.wizard-progress__item {
+  position: relative;
+  padding: clamp(1.1rem, 3.5vw, 1.4rem) clamp(0.9rem, 3vw, 1.4rem);
+  border-radius: var(--radius-4xl);
+  border: 1px solid rgba(237, 122, 122, 0.18);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--text-muted);
+  box-shadow: 0 10px 24px rgba(121, 137, 162, 0.12);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
+    background 0.2s ease;
+}
+
+.wizard-progress__index {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.35rem;
+}
+
+.wizard-progress__label {
+  display: block;
+  font-size: clamp(1rem, 2.4vw, 1.1rem);
+  font-weight: 600;
+}
+
+.wizard-progress__item.is-active {
+  border-color: rgba(237, 122, 122, 0.42);
+  color: var(--text-main);
+  background: linear-gradient(135deg, rgba(237, 122, 122, 0.18), rgba(237, 122, 122, 0.08));
+  box-shadow: 0 16px 28px rgba(237, 122, 122, 0.18);
+}
+
+.wizard-progress__item.is-complete {
+  border-color: rgba(98, 187, 161, 0.45);
+  background: linear-gradient(135deg, rgba(98, 187, 161, 0.18), rgba(255, 255, 255, 0.92));
+  color: var(--text-main);
+}
+
+.wizard-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.wizard-step__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wizard-step__eyebrow {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+
+.wizard-step__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.8vw, 1.55rem);
+}
+
+.wizard-step__description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: clamp(0.95rem, 2.5vw, 1.05rem);
+}
+
+.wizard-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.wizard-field label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.wizard-field input,
+.wizard-field textarea {
+  width: 100%;
+  font: inherit;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-3xl);
+  border: 1.5px solid rgba(237, 122, 122, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 4px rgba(140, 149, 178, 0.1);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.wizard-field input:focus,
+.wizard-field textarea:focus {
+  outline: none;
+  border-color: rgba(237, 122, 122, 0.55);
+  box-shadow: 0 0 0 3px rgba(237, 122, 122, 0.18);
+}
+
+.wizard-field textarea {
+  resize: vertical;
+  min-height: 6.4rem;
+}
+
+.wizard-field__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.field-required {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.35rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: var(--radius-full);
+  background: rgba(237, 122, 122, 0.2);
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.field-optional {
+  margin-left: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.wizard-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.wizard-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(237, 122, 122, 0.32);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-main);
+  font-weight: 600;
+  font-size: 0.98rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.wizard-button:hover,
+.wizard-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(237, 122, 122, 0.45);
+  box-shadow: 0 12px 24px rgba(121, 137, 162, 0.16);
+}
+
+.wizard-button:focus-visible {
+  outline: 3px solid rgba(237, 122, 122, 0.28);
+  outline-offset: 3px;
+}
+
+.wizard-button--primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+  border-color: rgba(237, 122, 122, 0.7);
+  color: #fff;
+  box-shadow: 0 14px 28px rgba(237, 122, 122, 0.28);
+}
+
+.wizard-button--primary:hover,
+.wizard-button--primary:focus-visible {
+  box-shadow: 0 18px 34px rgba(237, 122, 122, 0.35);
+}
+
+.wizard-feedback {
+  margin: 0;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-4xl);
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: rgba(98, 187, 161, 0.14);
+  color: var(--accent-green-deep);
+}
+
+.externalization-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.1rem, 3vw, 1.6rem);
+}
+
+.externalization-entry {
+  border: 1px solid rgba(98, 187, 161, 0.28);
+  border-radius: var(--radius-4xl);
+  padding: clamp(1.1rem, 3.5vw, 1.4rem) clamp(1rem, 3.5vw, 1.6rem);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 32px rgba(98, 187, 161, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.externalization-entry__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.externalization-entry__name {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.5vw, 1.3rem);
+  font-weight: 700;
+}
+
+.externalization-entry__scene {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.externalization-entry__body {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  font-size: 0.95rem;
+}
+
+.externalization-entry__body span {
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.externalization-entry__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.externalization-empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.text-button {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius-full);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.text-button:hover,
+.text-button:focus-visible {
+  background: rgba(237, 122, 122, 0.16);
+  color: var(--accent-orange-deep);
+}
+
+.text-button:focus-visible {
+  outline: 3px solid rgba(237, 122, 122, 0.25);
+  outline-offset: 3px;
+}
+
+.externalization-list[hidden],
+.externalization-empty[hidden] {
+  display: none;
+}
+
+.externalization-entry__delete {
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .externalization-card__header--list {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .wizard-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .wizard-button,
+  .wizard-button--primary {
+    width: 100%;
+  }
+
+  .externalization-entry {
+    padding: 1rem 1.2rem;
+  }
+
+  .externalization-entry__actions {
+    justify-content: flex-start;
+  }
+}

--- a/externalization-tool.html
+++ b/externalization-tool.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="自分を責める声を外に出し、優しいサポート役として再設定するためのツールです。キャラクターと使う場所を段階的に整理できます。">
+  <meta name="description" content="自分を責める声を外に書き出し、距離を取るための外部化ワーク。キャラクターと置き場所を段階的に整理できます。">
   <title>外部化ツール | フラッシュバック応急対処ガイド</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -29,9 +29,9 @@
       </p>
       <h1 class="hero-title">
         <span>外部化ツール</span>
-        <span>やさしい味方をつくる</span>
+        <span>責める声と距離をとる</span>
       </h1>
-      <p class="hero-lead">心の中の厳しい声を、頼れるサポート役として書き換えるためのワークです。<br>キャラクターと活用シーンを順番に整理して、日常で使える形に整えましょう。</p>
+      <p class="hero-lead">心の中で責め立ててくる声をキャラクターとして外に出し、距離を取るためのワークです。<br>キャラクターと置き場所を順番に整理して、現実の世界に位置づけましょう。</p>
       <div class="hero-actions">
         <a class="hero-link hero-link--guide" href="#externalization-wizard">
           <span class="hero-link__label">ワークを始める</span>
@@ -44,7 +44,7 @@
     <section class="usage-guide">
       <div class="inner surface-card surface-card--balanced">
         <h2 class="section-title">ツールの使い方</h2>
-        <p class="section-description">ステップに沿って入力するだけで、「どんな味方をつくるか」「どこで使うか」を整理できます。<br>入力した内容はブラウザに保存され、あとで一覧から見返せます。</p>
+        <p class="section-description">ステップに沿って入力するだけで、「責める声をどんなキャラクターとして切り離すか」「現実世界のどこに置くか」を整理できます。<br>入力した内容はブラウザに保存され、あとで一覧から見返せます。</p>
       </div>
     </section>
 
@@ -53,7 +53,7 @@
         <div class="externalization-card surface-card">
           <div class="externalization-card__header">
             <h2 class="section-title">ステップで作る外部化プラン</h2>
-            <p class="section-description">「キャラクターの設定」→「使う場所を決める」の順番で入力します。</p>
+            <p class="section-description">「キャラクターの設定」→「置き場所を決める」の順番で入力します。</p>
           </div>
 
           <ol class="wizard-progress" aria-label="外部化ツールのステップ">
@@ -63,7 +63,7 @@
             </li>
             <li class="wizard-progress__item" data-progress-step="1">
               <span class="wizard-progress__index">STEP 02</span>
-              <span class="wizard-progress__label">使う場所を決める</span>
+              <span class="wizard-progress__label">置き場所を決める</span>
             </li>
           </ol>
 
@@ -72,23 +72,23 @@
               <div class="wizard-step__header">
                 <p class="wizard-step__eyebrow">STEP 01</p>
                 <h3 id="step1-heading" class="wizard-step__title">キャラクターの設定</h3>
-                <p class="wizard-step__description">厳しい声の代わりに、自分を支えてくれるキャラクターを描いてみましょう。</p>
+                <p class="wizard-step__description">心の中の責める声を、外部化できるようにキャラクターとして描き出してみましょう。</p>
               </div>
 
               <div class="wizard-field" data-field="name">
-                <label for="character-name">キャラクターの名前 <span class="field-required">必須</span></label>
-                <input type="text" id="character-name" name="characterName" autocomplete="off" maxlength="40" placeholder="例：あったか森のガイド" required>
-                <p class="wizard-field__hint">呼びかけやすい名前にすると、安心を思い出しやすくなります。</p>
+                <label for="character-name">責める声に付ける名前 <span class="field-required">必須</span></label>
+                <input type="text" id="character-name" name="characterName" autocomplete="off" maxlength="40" placeholder="例：口うるさいコーチ、文句さん" required>
+                <p class="wizard-field__hint">名前を付けておくと「これは自分とは別の声だ」と切り離しやすくなります。</p>
               </div>
 
               <div class="wizard-field" data-field="persona">
-                <label for="character-persona">どんな雰囲気の人？ <span class="field-optional">任意</span></label>
-                <textarea id="character-persona" name="characterPersona" rows="3" maxlength="400" placeholder="外見・性格・口調などを書き留める"></textarea>
+                <label for="character-persona">どんな雰囲気で迫ってくる？ <span class="field-optional">任意</span></label>
+                <textarea id="character-persona" name="characterPersona" rows="3" maxlength="400" placeholder="外見・性格・口調、体格などを書き留める"></textarea>
               </div>
 
               <div class="wizard-field" data-field="support">
-                <label for="character-support">どんな言葉で支えてくれる？ <span class="field-optional">任意</span></label>
-                <textarea id="character-support" name="characterSupport" rows="3" maxlength="400" placeholder="例：「いま安全だよ」「深呼吸しようか」など"></textarea>
+                <label for="character-support">よく言ってくる言葉 <span class="field-optional">任意</span></label>
+                <textarea id="character-support" name="characterSupport" rows="3" maxlength="400" placeholder="例：「もっと頑張れ」「全部あなたのせい」など"></textarea>
               </div>
 
               <div class="wizard-actions">
@@ -99,24 +99,24 @@
             <section class="wizard-step" data-step-index="1" aria-labelledby="step2-heading" hidden>
               <div class="wizard-step__header">
                 <p class="wizard-step__eyebrow">STEP 02</p>
-                <h3 id="step2-heading" class="wizard-step__title">使う場所を決める</h3>
-                <p class="wizard-step__description">キャラクターをどこで思い出すか、日常の中の「配置場所」を考えましょう。</p>
+                <h3 id="step2-heading" class="wizard-step__title">置き場所を決める</h3>
+                <p class="wizard-step__description">外に出したキャラクターをどこに置くか決めて、目の前の現実に存在させましょう。</p>
               </div>
 
               <div class="wizard-field" data-field="scene">
-                <label for="support-scene">どんな場面で登場させたい？ <span class="field-required">必須</span></label>
-                <input type="text" id="support-scene" name="supportScene" autocomplete="off" maxlength="80" placeholder="例：朝の支度をするとき、寝る前など" required>
+                <label for="support-scene">どんな場面で現れてほしい？ <span class="field-required">必須</span></label>
+                <input type="text" id="support-scene" name="supportScene" autocomplete="off" maxlength="80" placeholder="例：自分を責めそうになった瞬間、仕事のチェック中など" required>
               </div>
 
               <div class="wizard-field" data-field="location">
-                <label for="support-location">思い出しやすい置き場所 <span class="field-optional">任意</span></label>
-                <input type="text" id="support-location" name="supportLocation" autocomplete="off" maxlength="80" placeholder="例：スマホの待ち受け、手帳の1ページ目" >
-                <p class="wizard-field__hint">以前の「部屋に置く」という表現をやめ、日常で目にする場所を自由に設定できます。</p>
+                <label for="support-location">外に出したものを置く場所 <span class="field-optional">任意</span></label>
+                <input type="text" id="support-location" name="supportLocation" autocomplete="off" maxlength="80" placeholder="例：ノートの中、机の上のフィギュア、スマホの待ち受け">
+                <p class="wizard-field__hint">日常で目にしやすい場所を書き出して、責める声を頭の外に置いておきましょう。</p>
               </div>
 
               <div class="wizard-field" data-field="action">
-                <label for="support-action">思い出したときのアクション <span class="field-optional">任意</span></label>
-                <textarea id="support-action" name="supportAction" rows="3" maxlength="400" placeholder="キャラクターを思い出したらどう行動するかを書き残しましょう"></textarea>
+                <label for="support-action">見かけたときにどう対応する？ <span class="field-optional">任意</span></label>
+                <textarea id="support-action" name="supportAction" rows="3" maxlength="400" placeholder="例：深呼吸をして距離を取る、声に返事をする"></textarea>
               </div>
 
               <div class="wizard-actions">

--- a/externalization-tool.html
+++ b/externalization-tool.html
@@ -104,8 +104,8 @@
               </div>
 
               <div class="wizard-field" data-field="scene">
-                <label for="support-scene">どんな場面で現れてほしい？ <span class="field-required">必須</span></label>
-                <input type="text" id="support-scene" name="supportScene" autocomplete="off" maxlength="80" placeholder="例：自分を責めそうになった瞬間、仕事のチェック中など" required>
+                <label for="support-scene">どんな場面で現れやすい？ <span class="field-required">必須</span></label>
+                <textarea id="support-scene" name="supportScene" rows="3" maxlength="400" placeholder="例：提出前の確認中、眠れない夜、SNSを見ているときなど" required></textarea>
               </div>
 
               <div class="wizard-field" data-field="location">

--- a/externalization-tool.html
+++ b/externalization-tool.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="自分を責める声を外に出し、優しいサポート役として再設定するためのツールです。キャラクターと使う場所を段階的に整理できます。">
+  <title>外部化ツール | フラッシュバック応急対処ガイド</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="externalization-tool.css">
+</head>
+<body class="externalization-page">
+  <div data-include="partials/quick-access.html"></div>
+
+  <header id="top" class="site-header externalization-header">
+    <div class="inner">
+      <p class="eyebrow" aria-label="Externalization Tool">
+        <span class="eyebrow-icon" aria-hidden="true">
+          <svg class="externalization-header__icon" viewBox="0 0 64 64" role="presentation" focusable="false">
+            <path d="M12 32a20 20 0 1 1 40 0 20 20 0 0 1-40 0Z" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"></path>
+            <path d="M32 17v8" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round"></path>
+            <path d="M24 36h16" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round"></path>
+            <path d="M20 44h8l4 7 4-7h8" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+        </span>
+        <span class="eyebrow-label">Externalization Tool</span>
+      </p>
+      <h1 class="hero-title">
+        <span>外部化ツール</span>
+        <span>やさしい味方をつくる</span>
+      </h1>
+      <p class="hero-lead">心の中の厳しい声を、頼れるサポート役として書き換えるためのワークです。<br>キャラクターと活用シーンを順番に整理して、日常で使える形に整えましょう。</p>
+      <div class="hero-actions">
+        <a class="hero-link hero-link--guide" href="#externalization-wizard">
+          <span class="hero-link__label">ワークを始める</span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class="externalization-main">
+    <section class="usage-guide">
+      <div class="inner surface-card surface-card--balanced">
+        <h2 class="section-title">ツールの使い方</h2>
+        <p class="section-description">ステップに沿って入力するだけで、「どんな味方をつくるか」「どこで使うか」を整理できます。<br>入力した内容はブラウザに保存され、あとで一覧から見返せます。</p>
+      </div>
+    </section>
+
+    <section id="externalization-wizard" class="externalization-section">
+      <div class="inner">
+        <div class="externalization-card surface-card">
+          <div class="externalization-card__header">
+            <h2 class="section-title">ステップで作る外部化プラン</h2>
+            <p class="section-description">「キャラクターの設定」→「使う場所を決める」の順番で入力します。</p>
+          </div>
+
+          <ol class="wizard-progress" aria-label="外部化ツールのステップ">
+            <li class="wizard-progress__item" data-progress-step="0">
+              <span class="wizard-progress__index">STEP 01</span>
+              <span class="wizard-progress__label">キャラクターの設定</span>
+            </li>
+            <li class="wizard-progress__item" data-progress-step="1">
+              <span class="wizard-progress__index">STEP 02</span>
+              <span class="wizard-progress__label">使う場所を決める</span>
+            </li>
+          </ol>
+
+          <form id="externalization-form" class="wizard-form" novalidate>
+            <section class="wizard-step" data-step-index="0" aria-labelledby="step1-heading">
+              <div class="wizard-step__header">
+                <p class="wizard-step__eyebrow">STEP 01</p>
+                <h3 id="step1-heading" class="wizard-step__title">キャラクターの設定</h3>
+                <p class="wizard-step__description">厳しい声の代わりに、自分を支えてくれるキャラクターを描いてみましょう。</p>
+              </div>
+
+              <div class="wizard-field" data-field="name">
+                <label for="character-name">キャラクターの名前 <span class="field-required">必須</span></label>
+                <input type="text" id="character-name" name="characterName" autocomplete="off" maxlength="40" placeholder="例：あったか森のガイド" required>
+                <p class="wizard-field__hint">呼びかけやすい名前にすると、安心を思い出しやすくなります。</p>
+              </div>
+
+              <div class="wizard-field" data-field="persona">
+                <label for="character-persona">どんな雰囲気の人？ <span class="field-optional">任意</span></label>
+                <textarea id="character-persona" name="characterPersona" rows="3" maxlength="400" placeholder="外見・性格・口調などを書き留める"></textarea>
+              </div>
+
+              <div class="wizard-field" data-field="support">
+                <label for="character-support">どんな言葉で支えてくれる？ <span class="field-optional">任意</span></label>
+                <textarea id="character-support" name="characterSupport" rows="3" maxlength="400" placeholder="例：「いま安全だよ」「深呼吸しようか」など"></textarea>
+              </div>
+
+              <div class="wizard-actions">
+                <button type="button" class="wizard-button wizard-button--primary" data-action="next">次へ</button>
+              </div>
+            </section>
+
+            <section class="wizard-step" data-step-index="1" aria-labelledby="step2-heading" hidden>
+              <div class="wizard-step__header">
+                <p class="wizard-step__eyebrow">STEP 02</p>
+                <h3 id="step2-heading" class="wizard-step__title">使う場所を決める</h3>
+                <p class="wizard-step__description">キャラクターをどこで思い出すか、日常の中の「配置場所」を考えましょう。</p>
+              </div>
+
+              <div class="wizard-field" data-field="scene">
+                <label for="support-scene">どんな場面で登場させたい？ <span class="field-required">必須</span></label>
+                <input type="text" id="support-scene" name="supportScene" autocomplete="off" maxlength="80" placeholder="例：朝の支度をするとき、寝る前など" required>
+              </div>
+
+              <div class="wizard-field" data-field="location">
+                <label for="support-location">思い出しやすい置き場所 <span class="field-optional">任意</span></label>
+                <input type="text" id="support-location" name="supportLocation" autocomplete="off" maxlength="80" placeholder="例：スマホの待ち受け、手帳の1ページ目" >
+                <p class="wizard-field__hint">以前の「部屋に置く」という表現をやめ、日常で目にする場所を自由に設定できます。</p>
+              </div>
+
+              <div class="wizard-field" data-field="action">
+                <label for="support-action">思い出したときのアクション <span class="field-optional">任意</span></label>
+                <textarea id="support-action" name="supportAction" rows="3" maxlength="400" placeholder="キャラクターを思い出したらどう行動するかを書き残しましょう"></textarea>
+              </div>
+
+              <div class="wizard-actions">
+                <button type="button" class="wizard-button" data-action="prev">戻る</button>
+                <button type="submit" class="wizard-button wizard-button--primary" data-action="save">保存する</button>
+              </div>
+            </section>
+          </form>
+          <p class="wizard-feedback" id="wizard-feedback" aria-live="polite" hidden></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="externalization-section">
+      <div class="inner">
+        <div class="externalization-card surface-card externalization-card--list">
+          <div class="externalization-card__header externalization-card__header--list">
+            <h2 class="section-title">保存したプラン</h2>
+            <button type="button" class="text-button" data-action="clear" aria-describedby="clear-description">すべて削除</button>
+          </div>
+          <p id="clear-description" class="section-description">保存内容はお使いの端末にのみ保存されます。不要になったら削除できます。</p>
+          <p class="externalization-empty" data-empty-message>まだ保存されたプランはありません。</p>
+          <ol class="externalization-list" id="externalization-list" aria-live="polite" aria-label="保存した外部化プラン"></ol>
+        </div>
+      </div>
+    </section>
+
+    <div data-include="partials/note.html"></div>
+  </main>
+
+  <div data-include="partials/site-footer.html"></div>
+
+  <div data-include="partials/back-to-top.html"></div>
+
+  <script src="component-loader.js" defer></script>
+  <script src="main.js" defer></script>
+  <script src="externalization-tool.js" defer></script>
+</body>
+</html>

--- a/externalization-tool.js
+++ b/externalization-tool.js
@@ -189,7 +189,7 @@
 
       const value = nameField.value.trim();
       if (!value) {
-        nameField.setCustomValidity('キャラクターの名前を入力してください');
+        nameField.setCustomValidity('責める声に付ける名前を入力してください');
         nameField.reportValidity();
         return false;
       }
@@ -205,7 +205,7 @@
 
       const value = sceneField.value.trim();
       if (!value) {
-        sceneField.setCustomValidity('キャラクターを登場させたい場面を書いてください');
+        sceneField.setCustomValidity('現れてほしい場面を書いてください');
         sceneField.reportValidity();
         return false;
       }
@@ -286,7 +286,7 @@
 
       const scene = document.createElement('p');
       scene.className = 'externalization-entry__scene';
-      scene.textContent = `登場シーン：${entry.supportScene}`;
+      scene.textContent = `現れてほしい場面：${entry.supportScene}`;
       header.appendChild(scene);
 
       item.appendChild(header);
@@ -295,19 +295,19 @@
       bodyList.className = 'externalization-entry__body';
 
       if (entry.characterPersona) {
-        bodyList.appendChild(createDetailItem('キャラクター像', entry.characterPersona));
+        bodyList.appendChild(createDetailItem('雰囲気や特徴', entry.characterPersona));
       }
 
       if (entry.characterSupport) {
-        bodyList.appendChild(createDetailItem('かけてもらいたい言葉', entry.characterSupport));
+        bodyList.appendChild(createDetailItem('よく言ってくる言葉', entry.characterSupport));
       }
 
       if (entry.supportLocation) {
-        bodyList.appendChild(createDetailItem('思い出しやすい場所', entry.supportLocation));
+        bodyList.appendChild(createDetailItem('置いておく場所', entry.supportLocation));
       }
 
       if (entry.supportAction) {
-        bodyList.appendChild(createDetailItem('思い出したときのアクション', entry.supportAction));
+        bodyList.appendChild(createDetailItem('見かけたときの対応', entry.supportAction));
       }
 
       if (bodyList.children.length) {

--- a/externalization-tool.js
+++ b/externalization-tool.js
@@ -205,7 +205,7 @@
 
       const value = sceneField.value.trim();
       if (!value) {
-        sceneField.setCustomValidity('現れてほしい場面を書いてください');
+        sceneField.setCustomValidity('現れやすい場面を書いてください');
         sceneField.reportValidity();
         return false;
       }
@@ -286,7 +286,7 @@
 
       const scene = document.createElement('p');
       scene.className = 'externalization-entry__scene';
-      scene.textContent = `現れてほしい場面：${entry.supportScene}`;
+      scene.textContent = `現れやすい場面：${entry.supportScene}`;
       header.appendChild(scene);
 
       item.appendChild(header);

--- a/externalization-tool.js
+++ b/externalization-tool.js
@@ -1,0 +1,410 @@
+(() => {
+  'use strict';
+
+  const STORAGE_KEY = 'externalizationPlans';
+  const stepsState = {
+    current: 0,
+    steps: [],
+    progressIndicators: [],
+  };
+
+  const elements = {
+    form: null,
+    feedback: null,
+    entriesList: null,
+    emptyMessage: null,
+    clearButton: null,
+  };
+
+  const storage = getStorage();
+  const entries = storage ? loadEntries() : [];
+
+  whenDocumentReady(() => {
+    initializeForm();
+    initializeList();
+  });
+
+  function whenDocumentReady(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function initializeForm() {
+    const form = document.getElementById('externalization-form');
+    if (!form) {
+      return;
+    }
+
+    elements.form = form;
+    elements.feedback = document.getElementById('wizard-feedback');
+
+    stepsState.steps = Array.from(form.querySelectorAll('[data-step-index]'));
+    stepsState.progressIndicators = Array.from(
+      document.querySelectorAll('[data-progress-step]')
+    );
+
+    attachFieldReset('#character-name');
+    attachFieldReset('#support-scene');
+
+    form.addEventListener('submit', handleSubmit);
+
+    form.querySelectorAll('[data-action="next"]').forEach((button) => {
+      button.addEventListener('click', handleNextStep);
+    });
+
+    form.querySelectorAll('[data-action="prev"]').forEach((button) => {
+      button.addEventListener('click', handlePreviousStep);
+    });
+
+    showStep(0);
+  }
+
+  function initializeList() {
+    elements.entriesList = document.getElementById('externalization-list');
+    elements.emptyMessage = document.querySelector('[data-empty-message]');
+    elements.clearButton = document.querySelector('[data-action="clear"]');
+
+    if (elements.entriesList) {
+      elements.entriesList.addEventListener('click', handleListClick);
+    }
+
+  if (elements.clearButton) {
+    elements.clearButton.addEventListener('click', handleClearAll);
+    if (!storage) {
+      elements.clearButton.title = 'ブラウザの保存機能が利用できないため、ページを離れるとリストが消える可能性があります';
+    }
+  }
+
+    renderEntries(entries);
+  }
+
+  function attachFieldReset(selector) {
+    const field = document.querySelector(selector);
+    if (!field) {
+      return;
+    }
+
+    field.addEventListener('input', () => {
+      field.setCustomValidity('');
+    });
+  }
+
+  function handleNextStep(event) {
+    event.preventDefault();
+    clearFeedback();
+
+    if (!validateStep(stepsState.current)) {
+      return;
+    }
+
+    const nextIndex = Math.min(stepsState.current + 1, stepsState.steps.length - 1);
+    showStep(nextIndex);
+  }
+
+  function handlePreviousStep(event) {
+    event.preventDefault();
+    clearFeedback();
+
+    const previousIndex = Math.max(stepsState.current - 1, 0);
+    showStep(previousIndex);
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    clearFeedback();
+
+    if (!validateStep(0) || !validateStep(1)) {
+      return;
+    }
+
+    const form = elements.form;
+    if (!form) {
+      return;
+    }
+
+    const formData = new FormData(form);
+    const entry = createEntryFromForm(formData);
+    if (!entry) {
+      return;
+    }
+
+    entries.unshift(entry);
+    persistEntries();
+    renderEntries(entries);
+
+    form.reset();
+    showStep(0);
+    const message = storage
+      ? '保存しました。日常の中で味方を呼び出してみましょう。'
+      : '保存しました（この端末では自動保存が無効のため、ページを離れると内容が消える場合があります）。';
+    displayFeedback(message);
+  }
+
+  function handleListClick(event) {
+    const deleteButton = event.target.closest('[data-action="delete"]');
+    if (!deleteButton || !elements.entriesList || !elements.entriesList.contains(deleteButton)) {
+      return;
+    }
+
+    const entryId = deleteButton.getAttribute('data-entry-id');
+    if (!entryId) {
+      return;
+    }
+
+    const index = entries.findIndex((entry) => entry.id === entryId);
+    if (index === -1) {
+      return;
+    }
+
+    entries.splice(index, 1);
+    persistEntries();
+    renderEntries(entries);
+  }
+
+  function handleClearAll() {
+    if (!entries.length) {
+      return;
+    }
+
+    entries.splice(0, entries.length);
+    persistEntries();
+    renderEntries(entries);
+    displayFeedback('保存されていたプランを削除しました。');
+  }
+
+  function validateStep(stepIndex) {
+    const form = elements.form;
+    if (!form) {
+      return false;
+    }
+
+    if (stepIndex === 0) {
+      const nameField = form.querySelector('#character-name');
+      if (!nameField) {
+        return false;
+      }
+
+      const value = nameField.value.trim();
+      if (!value) {
+        nameField.setCustomValidity('キャラクターの名前を入力してください');
+        nameField.reportValidity();
+        return false;
+      }
+      nameField.setCustomValidity('');
+      return true;
+    }
+
+    if (stepIndex === 1) {
+      const sceneField = form.querySelector('#support-scene');
+      if (!sceneField) {
+        return false;
+      }
+
+      const value = sceneField.value.trim();
+      if (!value) {
+        sceneField.setCustomValidity('キャラクターを登場させたい場面を書いてください');
+        sceneField.reportValidity();
+        return false;
+      }
+      sceneField.setCustomValidity('');
+      return true;
+    }
+
+    return true;
+  }
+
+  function showStep(targetIndex) {
+    stepsState.current = targetIndex;
+
+    stepsState.steps.forEach((step, index) => {
+      const isCurrent = index === targetIndex;
+      step.hidden = !isCurrent;
+      if (isCurrent) {
+        const firstField = step.querySelector('input, textarea');
+        if (firstField) {
+          firstField.focus({ preventScroll: true });
+        }
+      }
+    });
+
+    stepsState.progressIndicators.forEach((indicator, index) => {
+      indicator.classList.toggle('is-active', index === targetIndex);
+      indicator.classList.toggle('is-complete', index < targetIndex);
+    });
+  }
+
+  function createEntryFromForm(formData) {
+    const name = (formData.get('characterName') || '').toString().trim();
+    const scene = (formData.get('supportScene') || '').toString().trim();
+    if (!name || !scene) {
+      return null;
+    }
+
+    return {
+      id: generateId(),
+      createdAt: new Date().toISOString(),
+      characterName: name,
+      characterPersona: (formData.get('characterPersona') || '').toString().trim(),
+      characterSupport: (formData.get('characterSupport') || '').toString().trim(),
+      supportScene: scene,
+      supportLocation: (formData.get('supportLocation') || '').toString().trim(),
+      supportAction: (formData.get('supportAction') || '').toString().trim(),
+    };
+  }
+
+  function renderEntries(list) {
+    if (!elements.entriesList || !elements.emptyMessage) {
+      return;
+    }
+
+    elements.entriesList.innerHTML = '';
+
+    if (!list.length) {
+      elements.entriesList.hidden = true;
+      elements.emptyMessage.hidden = false;
+      return;
+    }
+
+    elements.entriesList.hidden = false;
+    elements.emptyMessage.hidden = true;
+
+    list.forEach((entry) => {
+      const item = document.createElement('li');
+      item.className = 'externalization-entry';
+      item.dataset.entryId = entry.id;
+
+      const header = document.createElement('div');
+      header.className = 'externalization-entry__header';
+
+      const name = document.createElement('h3');
+      name.className = 'externalization-entry__name';
+      name.textContent = entry.characterName;
+      header.appendChild(name);
+
+      const scene = document.createElement('p');
+      scene.className = 'externalization-entry__scene';
+      scene.textContent = `登場シーン：${entry.supportScene}`;
+      header.appendChild(scene);
+
+      item.appendChild(header);
+
+      const bodyList = document.createElement('ul');
+      bodyList.className = 'externalization-entry__body';
+
+      if (entry.characterPersona) {
+        bodyList.appendChild(createDetailItem('キャラクター像', entry.characterPersona));
+      }
+
+      if (entry.characterSupport) {
+        bodyList.appendChild(createDetailItem('かけてもらいたい言葉', entry.characterSupport));
+      }
+
+      if (entry.supportLocation) {
+        bodyList.appendChild(createDetailItem('思い出しやすい場所', entry.supportLocation));
+      }
+
+      if (entry.supportAction) {
+        bodyList.appendChild(createDetailItem('思い出したときのアクション', entry.supportAction));
+      }
+
+      if (bodyList.children.length) {
+        item.appendChild(bodyList);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'externalization-entry__actions';
+
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'text-button externalization-entry__delete';
+      deleteButton.dataset.action = 'delete';
+      deleteButton.dataset.entryId = entry.id;
+      deleteButton.textContent = '削除';
+
+      actions.appendChild(deleteButton);
+      item.appendChild(actions);
+
+      elements.entriesList.appendChild(item);
+    });
+  }
+
+  function createDetailItem(label, value) {
+    const item = document.createElement('li');
+    const labelSpan = document.createElement('span');
+    labelSpan.textContent = `${label}：`;
+    item.appendChild(labelSpan);
+
+    const text = document.createTextNode(value);
+    item.appendChild(text);
+
+    return item;
+  }
+
+  function displayFeedback(message) {
+    if (!elements.feedback) {
+      return;
+    }
+
+    elements.feedback.hidden = false;
+    elements.feedback.textContent = message;
+  }
+
+  function clearFeedback() {
+    if (!elements.feedback) {
+      return;
+    }
+
+    elements.feedback.hidden = true;
+    elements.feedback.textContent = '';
+  }
+
+  function persistEntries() {
+    if (!storage) {
+      return;
+    }
+
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch (error) {
+      console.error('外部化プランの保存に失敗しました', error);
+    }
+  }
+
+  function loadEntries() {
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.filter((entry) => entry && typeof entry.id === 'string');
+    } catch (error) {
+      console.error('外部化プランの読み込みに失敗しました', error);
+      return [];
+    }
+  }
+
+  function getStorage() {
+    try {
+      const testKey = '__externalization_tool__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return window.localStorage;
+    } catch (error) {
+      console.warn('ローカルストレージが利用できません', error);
+      return null;
+    }
+  }
+
+  function generateId() {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+})();

--- a/partials/quick-access.html
+++ b/partials/quick-access.html
@@ -19,6 +19,15 @@
       </span>
       <span class="quick-access__label">ロードマップ</span>
     </a>
+    <a href="externalization-tool.html" class="quick-access__link quick-access__link--externalization">
+      <span class="quick-access__icon" aria-hidden="true">
+        <svg class="quick-access__icon-svg" viewBox="0 0 24 24" role="presentation" focusable="false">
+          <path d="M4.5 5.5h10a3 3 0 0 1 3 3v2.2a3 3 0 0 1-3 3H11l-3.4 3v-3H4.5a3 3 0 0 1-3-3V8.5a3 3 0 0 1 3-3Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+          <path d="M12.5 12.5h6a2.5 2.5 0 0 1 2.5 2.5v1.6a2.5 2.5 0 0 1-2.5 2.5h-1.8l-2.4 2.2v-2.2h-1.8a2.5 2.5 0 0 1-2.5-2.5v-1.6a2.5 2.5 0 0 1 2.5-2.5Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+      </span>
+      <span class="quick-access__label">外部化ツール</span>
+    </a>
     <a href="trigger-log.html" class="quick-access__link quick-access__link--log" rel="noopener noreferrer">
       <span class="quick-access__icon" aria-hidden="true">
         <svg class="quick-access__icon-svg" viewBox="0 0 24 24" role="presentation" focusable="false">

--- a/styles.css
+++ b/styles.css
@@ -235,6 +235,29 @@ img {
   outline: 3px solid rgba(255, 166, 110, 0.45);
 }
 
+.quick-access__link--externalization {
+  background: linear-gradient(135deg, rgba(142, 152, 235, 0.92), rgba(105, 178, 230, 0.88));
+  color: #fff;
+  border-color: rgba(120, 150, 230, 0.6);
+  box-shadow: 0 8px 24px rgba(120, 150, 230, 0.28);
+}
+
+.quick-access__link--externalization .quick-access__icon {
+  color: currentColor;
+}
+
+.quick-access__link--externalization:hover,
+.quick-access__link--externalization:focus-visible {
+  background: linear-gradient(135deg, rgba(158, 168, 240, 0.98), rgba(113, 186, 238, 0.95));
+  border-color: rgba(120, 150, 230, 0.75);
+  color: #fff;
+  box-shadow: 0 14px 32px rgba(120, 150, 230, 0.34);
+}
+
+.quick-access__link--externalization:focus-visible {
+  outline: 3px solid rgba(120, 150, 230, 0.36);
+}
+
 .quick-access__link--log {
   background: linear-gradient(135deg, var(--accent-green), var(--accent-green-deep));
   color: #fff;


### PR DESCRIPTION
## Summary
- add a new externalization-tool page with a guided two-step wizard
- update quick access navigation and styling for the renamed 外部化ツール wording
- persist saved plans locally and expose management controls

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68db1590a22c8326a856419878737b41